### PR TITLE
Biblioteca de modelos de peças para guiar a minuta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,6 +600,47 @@ comum** (sem tools/skills/`container`) — por isso funciona nos dois provedores
 - `vendor/` é **intocado**; nenhum bundle entra em página de tribunal. `src/editor.html`
   está em `web_accessible_resources` (aberto de `*.jus.br`); os subrecursos não precisam.
 
+## Biblioteca de modelos de peças (`modelos.js` + `panel.js` + `content.js`)
+
+Peças-modelo do usuário (sentenças, decisões, despachos, ofícios, atas, mandados) para
+o assistente **imitar a forma** ao gerar minutas. `src/modelos.js` expõe o global `MLIB`,
+irmão do `PLIB`, com diferenças de propósito:
+
+- **`chrome.storage.local`, um item por modelo** (`modelo:<id>`), NÃO `sync`: uma
+  peça-modelo (mesmo real) passa dos 8.192 B/item do sync. `AREA` é o único ponto de
+  troca; o `aoMudar` filtra área `local` + prefixo `modelo:` para não colidir com o
+  `onChanged` de config do content.js nem com o do `PLIB` (área `sync`). Cada item tem
+  **categoria** (a espécie) e descrição além de título + texto. Teto por item
+  `TETO_BYTES` = 60000 (barreira de sanidade, não da API — local não tem cota por item).
+- **Gated a modelos de 1M tokens** (`setModelosHabilitado` no painel, chamado por
+  `aplicarCapsNaUI` com `caps.contextTokens >= 1000000`): a minuta manda os autos
+  inteiros + vários modelos, o que só cabe nas janelas de 1M — no Haiku (200k) o botão
+  **📚 Modelos** e o seletor da minuta somem (a minuta comum segue funcionando). Ao vivo
+  na troca de modelo; fecha o modal se ele estiver aberto quando desabilita.
+- **Seleção por CATEGORIA, não por modelo** (decisão de produto): o seletor da
+  `.minutabar` escolhe uma espécie e `modelosMinutaSelecionados()` reúne TODOS os modelos
+  daquela categoria (ordenados por recência) até dois tetos — `MODELOS_MAX_ENVIO` (12) e
+  `MODELOS_TETO_CHARS` (180000, ~45k tokens; o 1º sempre entra). Corte avisado no console
+  (sem cap silencioso). A categoria é pré-selecionada por `detectarCategoria` (espelha o
+  agrupamento de `MINUTA_ESPECIE`); o usuário pode trocar. Passa via `minutaCb(t, sel,
+  modelos)` — a assinatura ganhou o 3º arg, e sem modelos o comportamento é byte a byte
+  o de antes.
+- **Moldura anti-contaminação** (`molduraModelos` em content.js): o(s) modelo(s) entram
+  como **um bloco de texto** (nunca `document`/`file_id` — não é peça dos autos, não é
+  citável) e é o **PRIMEIRO** do content da minuta (antes das peças, no prefixo
+  cacheado). Vai em **XML** (`<modelos_de_referencia>` com `<modelo n="i">`), não
+  Markdown, porque o conteúdo interno é Markdown e a tag é a única fronteira que o modelo
+  não confunde com a resposta. A instrução manda **analisar, escolher a base mais
+  adequada e reaproveitar estrutura e LINGUAGEM** das outras, mas **nenhum FATO** (nomes,
+  valores, datas, dispositivos) — esses saem só das peças do processo em tela; o que
+  faltar vira `[COMPLETAR: …]`. Tags `<modelo…>` acidentais no texto do usuário são
+  removidas (regex `limpar`) para não quebrar a moldura — o `<` comum do texto jurídico é
+  preservado.
+- **Funciona nos DOIS provedores** (a minuta é chat comum, sem gating por nome de
+  modelo) e grava **trecho de outros processos no disco** (como os rascunhos de minuta):
+  daí a nota no `PRIVACY.md`/`help.html` e a exclusão fácil na biblioteca (dois cliques,
+  nunca `confirm()` nativo). O modal `.mlib` reaproveita todo o visual do `.plib`.
+
 ## Mapa mental (markmap) — página `src/mapa.html`
 
 Botão "🧠 Mapa mental" na barra de ferramentas liga o **modo mapa** (`setMapaMode` em

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -21,7 +21,7 @@ são enviados diretamente do seu navegador à API do provedor de IA que você es
 | **Preferências** (modelo, nível de raciocínio, instruções personalizadas, modo de layout) | Funcionamento da interface | Somente `chrome.storage.local`. As instruções personalizadas são anexadas ao prompt enviado ao provedor escolhido. |
 | **Prompts salvos** (título e texto que você escreve na biblioteca de prompts) | Reaproveitar instruções suas nas conversas | `chrome.storage.sync`: ficam no seu navegador e, se você usar o Chrome com uma conta Google e a sincronização ligada, o próprio Chrome os replica nos seus outros dispositivos (o desenvolvedor não tem acesso). O texto do prompt vai ao provedor de IA junto da mensagem quando você o usa. |
 | **Rascunhos de minuta** (o texto que o modelo gera ao usar “Minutar” ou “Abrir no editor”, com o que você editar) | Permitir reabrir e continuar a minuta depois, inclusive noutro dia | `chrome.storage.local` — **ficam gravados neste computador**, não sincronizam e não saem dele. São apagados automaticamente após 7 dias (mantidos no máximo os 10 mais recentes); o botão **Descartar**, no editor, remove um rascunho na hora. |
-| **Modelos de peças** (as peças-modelo que você cadastra na biblioteca “Modelos”: título, categoria, descrição e texto) | Servir de referência de **forma** ao gerar minutas — o assistente imita a estrutura e o estilo do modelo | `chrome.storage.local` — **ficam gravados neste computador**, não sincronizam e não saem dele. Se você colar uma peça real, ela pode conter dados de **outro** processo; use o botão **excluir** da biblioteca para removê-la a qualquer momento. O texto do modelo escolhido vai ao provedor de IA junto do pedido de minuta, com a instrução expressa de copiar apenas a forma, nunca os fatos. |
+| **Modelos de peças** (as peças-modelo que você cadastra na biblioteca “Modelos”: título, categoria, descrição e texto) | Servir de referência de **forma** ao gerar minutas — o assistente segue a estrutura e o estilo dos seus modelos | `chrome.storage.local` — **ficam gravados neste computador**, não sincronizam e não saem dele. Se você colar uma peça real, ela pode conter dados de **outro** processo; use o botão **excluir** da biblioteca para removê-la a qualquer momento. Ao gerar uma minuta com uma categoria escolhida, os textos das peças-modelo daquela categoria (até um teto) vão ao provedor de IA junto do pedido, com a instrução expressa de aproveitar apenas a forma e a linguagem, nunca os fatos. |
 | **Sessão do PJe** (cookies do tribunal) | Baixar as peças que você marcar, pelo mesmo mecanismo que o próprio PJe usa | Os cookies são gerenciados pelo navegador e **nunca são lidos, armazenados ou exportados pela extensão** — as requisições ao tribunal usam a sessão já aberta por você, e o conteúdo baixado fica em cache temporário na memória da aba. |
 
 Nenhum dado além dos listados acima é tratado. A coleta limita-se ao estritamente
@@ -86,10 +86,11 @@ de ajuda.
 - **Modelos de peças** (biblioteca “Modelos”) também ficam no `chrome.storage.local`, sem
   poda automática e sem sincronizar. Se você cadastrar uma peça real como modelo, o texto
   pode conter dados de **outro** processo; ele fica só neste navegador e o botão **excluir**
-  da biblioteca o remove quando você quiser. Ao gerar uma minuta com um modelo escolhido, o
-  texto do modelo vai ao provedor de IA numa moldura `<modelos_de_referencia>` com a
-  instrução expressa de que serve **apenas de forma** — nenhum fato do modelo pode entrar na
-  minuta, que se baseia só nas peças do processo em tela.
+  da biblioteca o remove quando você quiser. Ao gerar uma minuta com uma categoria escolhida,
+  os textos das peças-modelo daquela categoria (até um teto de quantidade/tamanho) vão ao
+  provedor de IA numa moldura `<modelos_de_referencia>` com a instrução expressa de que
+  servem **apenas de forma e linguagem** — nenhum fato dos modelos pode entrar na minuta, que
+  se baseia só nas peças do processo em tela.
 - A única exceção são os **prompts salvos**, gravados no `chrome.storage.sync` para
   acompanharem você em outros dispositivos: quem os replica é o próprio Chrome, pela
   sincronização da sua conta Google. Sem conta ou com a sincronização desligada, eles

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -21,6 +21,7 @@ são enviados diretamente do seu navegador à API do provedor de IA que você es
 | **Preferências** (modelo, nível de raciocínio, instruções personalizadas, modo de layout) | Funcionamento da interface | Somente `chrome.storage.local`. As instruções personalizadas são anexadas ao prompt enviado ao provedor escolhido. |
 | **Prompts salvos** (título e texto que você escreve na biblioteca de prompts) | Reaproveitar instruções suas nas conversas | `chrome.storage.sync`: ficam no seu navegador e, se você usar o Chrome com uma conta Google e a sincronização ligada, o próprio Chrome os replica nos seus outros dispositivos (o desenvolvedor não tem acesso). O texto do prompt vai ao provedor de IA junto da mensagem quando você o usa. |
 | **Rascunhos de minuta** (o texto que o modelo gera ao usar “Minutar” ou “Abrir no editor”, com o que você editar) | Permitir reabrir e continuar a minuta depois, inclusive noutro dia | `chrome.storage.local` — **ficam gravados neste computador**, não sincronizam e não saem dele. São apagados automaticamente após 7 dias (mantidos no máximo os 10 mais recentes); o botão **Descartar**, no editor, remove um rascunho na hora. |
+| **Modelos de peças** (as peças-modelo que você cadastra na biblioteca “Modelos”: título, categoria, descrição e texto) | Servir de referência de **forma** ao gerar minutas — o assistente imita a estrutura e o estilo do modelo | `chrome.storage.local` — **ficam gravados neste computador**, não sincronizam e não saem dele. Se você colar uma peça real, ela pode conter dados de **outro** processo; use o botão **excluir** da biblioteca para removê-la a qualquer momento. O texto do modelo escolhido vai ao provedor de IA junto do pedido de minuta, com a instrução expressa de copiar apenas a forma, nunca os fatos. |
 | **Sessão do PJe** (cookies do tribunal) | Baixar as peças que você marcar, pelo mesmo mecanismo que o próprio PJe usa | Os cookies são gerenciados pelo navegador e **nunca são lidos, armazenados ou exportados pela extensão** — as requisições ao tribunal usam a sessão já aberta por você, e o conteúdo baixado fica em cache temporário na memória da aba. |
 
 Nenhum dado além dos listados acima é tratado. A coleta limita-se ao estritamente
@@ -76,12 +77,19 @@ de ajuda.
 - Todos os dados persistentes (chaves e preferências) ficam no `chrome.storage.local`
   do seu navegador. Caches de sessão (uploads, peças baixadas) vivem na memória da aba
   ou no `chrome.storage.session` e desaparecem ao fechar o navegador.
-- **Rascunhos de minuta** também ficam no `chrome.storage.local` — é a única
-  funcionalidade que grava **trecho dos autos** de forma persistente no disco (para você
+- **Rascunhos de minuta** também ficam no `chrome.storage.local` — é uma das
+  funcionalidades que gravam **trecho dos autos** de forma persistente no disco (para você
   reabrir a minuta depois). São podados sozinhos após 7 dias e limitados aos 10 mais
   recentes; **Descartar**, no editor, apaga na hora. Não sincronizam entre dispositivos.
   Ao gerar o `.docx` ou imprimir a partir do editor, o arquivo resultante é salvo por
   **você**, onde você escolher, e deixa de estar sob controle da extensão.
+- **Modelos de peças** (biblioteca “Modelos”) também ficam no `chrome.storage.local`, sem
+  poda automática e sem sincronizar. Se você cadastrar uma peça real como modelo, o texto
+  pode conter dados de **outro** processo; ele fica só neste navegador e o botão **excluir**
+  da biblioteca o remove quando você quiser. Ao gerar uma minuta com um modelo escolhido, o
+  texto do modelo vai ao provedor de IA numa moldura `<modelos_de_referencia>` com a
+  instrução expressa de que serve **apenas de forma** — nenhum fato do modelo pode entrar na
+  minuta, que se baseia só nas peças do processo em tela.
 - A única exceção são os **prompts salvos**, gravados no `chrome.storage.sync` para
   acompanharem você em outros dispositivos: quem os replica é o próprio Chrome, pela
   sincronização da sua conta Google. Sem conta ou com a sincronização desligada, eles

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
   "content_scripts": [
     {
       "matches": ["https://*.jus.br/*"],
-      "js": ["src/pje.js", "src/prompts.js", "src/panel.js", "src/content.js"],
+      "js": ["src/pje.js", "src/prompts.js", "src/modelos.js", "src/panel.js", "src/content.js"],
       "run_at": "document_idle"
     }
   ],

--- a/src/content.js
+++ b/src/content.js
@@ -284,6 +284,9 @@
       }
     );
     panel.setModoCitacoes(modelCaps.citacoesNativas === false ? "textual" : "nativa");
+    // A biblioteca de modelos assume 1M tokens (a minuta manda os autos + vários
+    // modelos): habilitada só nesses; nos menores (Haiku) a feature some.
+    panel.setModelosHabilitado((modelCaps.contextTokens || 0) >= 1000000);
     const prov = modelCaps.provider || "anthropic";
     if (conversation.length && conversaProvider && prov !== conversaProvider) {
       panel.setAlerta(ALERTA_TROCA_PROVEDOR);

--- a/src/content.js
+++ b/src/content.js
@@ -1461,7 +1461,48 @@
     " NÃO assine, não date e não crie cabeçalho de tribunal, vara ou comarca — isso o" +
     " sistema do PJe já acrescenta.";
 
-  panel.onMinuta(async (text, selectedIds) => {
+  // Quando o usuário escolhe uma peça-modelo (biblioteca MLIB), o texto dela
+  // entra no request da minuta como MOLDURA de FORMA — nunca de conteúdo. Vai
+  // como bloco de texto e é o PRIMEIRO do content (antes das peças), para
+  // ficar no prefixo cacheado. A regra anti-contaminação é dura de propósito:
+  // o modelo é de OUTRO processo e traz nomes, valores e datas que NÃO podem
+  // vazar para a minuta. XML (não Markdown) porque o conteúdo interno é
+  // Markdown — a tag é a única fronteira que o modelo não confunde com a
+  // resposta. Tags <modelo…> acidentais no texto do usuário são removidas para
+  // não quebrar a moldura.
+  function molduraModelos(modelo) {
+    if (!modelo || !modelo.texto) return null;
+    const texto = String(modelo.texto).replace(/<\/?modelos?(_de_referencia)?\b[^>]*>/gi, "");
+    const cat = modelo.categoria
+      ? ' categoria="' + String(modelo.categoria).replace(/"/g, "") + '"'
+      : "";
+    const tit = modelo.titulo
+      ? ' titulo="' + String(modelo.titulo).replace(/"/g, "'") + '"'
+      : "";
+    return {
+      type: "text",
+      text:
+        "<modelos_de_referencia>\n" +
+        "O bloco <modelo> abaixo é uma peça-modelo que o usuário cadastrou para você " +
+        "imitar APENAS a FORMA: a estrutura das seções, a ordem, o fraseado e o tom " +
+        "forense. Ela é de OUTRO processo.\n" +
+        "REGRA ABSOLUTA: não copie NENHUM fato do modelo — nomes de partes, números, " +
+        "datas, valores, endereços, dispositivos legais, fundamentos ou trechos " +
+        "específicos. Todo o conteúdo da minuta sai EXCLUSIVAMENTE das peças deste " +
+        "processo, anexadas em seguida. Se o modelo trouxer um dado que não conste " +
+        "dessas peças, use [COMPLETAR: …] no lugar. O modelo é a forma; os autos são " +
+        "o conteúdo.\n" +
+        "<modelo" +
+        cat +
+        tit +
+        ">\n" +
+        texto +
+        "\n</modelo>\n" +
+        "</modelos_de_referencia>",
+    };
+  }
+
+  panel.onMinuta(async (text, selectedIds, modelo) => {
     if (busy) return;
     if (selectedIds.length === 0) {
       panel.setStatus("Marque as peças que devem embasar a minuta.");
@@ -1471,9 +1512,12 @@
     panel.lockInput(true);
 
     const instrucao = (text && text.trim()) || INSTRUCAO_MINUTA_PADRAO;
+    const molduraBloco = molduraModelos(modelo);
     panel.addMessage(
       "user",
-      "📝 Gerar minuta: " + instrucao,
+      "📝 Gerar minuta: " +
+        instrucao +
+        (molduraBloco ? "\n\n📚 Seguindo o modelo: " + (modelo.titulo || "sem título") : ""),
       selectedIds.map((id) => metaDe(id).titulo)
     );
     let assistantEl = null;
@@ -1492,11 +1536,19 @@
 
       // Request ISOLADO, como o mapa mental: não entra em conversation nem em
       // pecasNaConversa — gerar uma minuta não altera a conversa em andamento.
+      // A moldura do modelo (se houver) é o PRIMEIRO bloco: fica antes das
+      // peças, no prefixo cacheado, e o reforço na instrução volta a amarrar
+      // "forma do modelo, fatos das peças".
+      const reforcoModelo = molduraBloco
+        ? " Siga a ESTRUTURA e o estilo do modelo de referência fornecido no início," +
+          " mas com os FATOS exclusivamente das peças deste processo."
+        : "";
       const messages = prepararEnvio(
         [
           {
             role: "user",
             content: [
+              ...(molduraBloco ? [molduraBloco] : []),
               ...blocos,
               {
                 type: "text",
@@ -1507,6 +1559,7 @@
                 text:
                   instrucao +
                   SUFIXO_MINUTA +
+                  reforcoModelo +
                   " Peças anexadas, use exatamente estes ids: " +
                   selectedIds.map((id) => metaDe(id).titulo).join("; ") +
                   ".",

--- a/src/content.js
+++ b/src/content.js
@@ -1461,48 +1461,52 @@
     " NÃO assine, não date e não crie cabeçalho de tribunal, vara ou comarca — isso o" +
     " sistema do PJe já acrescenta.";
 
-  // Quando o usuário escolhe uma peça-modelo (biblioteca MLIB), o texto dela
-  // entra no request da minuta como MOLDURA de FORMA — nunca de conteúdo. Vai
-  // como bloco de texto e é o PRIMEIRO do content (antes das peças), para
-  // ficar no prefixo cacheado. A regra anti-contaminação é dura de propósito:
-  // o modelo é de OUTRO processo e traz nomes, valores e datas que NÃO podem
-  // vazar para a minuta. XML (não Markdown) porque o conteúdo interno é
+  // Quando o usuário escolhe uma categoria de modelos (biblioteca MLIB), TODAS
+  // as peças-modelo daquela espécie (o painel já aplica o teto) entram no
+  // request da minuta como MOLDURA de FORMA — nunca de conteúdo. Vai como bloco
+  // de texto e é o PRIMEIRO do content (antes das peças), para ficar no prefixo
+  // cacheado. A regra anti-contaminação é dura de propósito: os modelos são de
+  // OUTROS processos e trazem nomes, valores e datas que NÃO podem vazar para a
+  // minuta. A IA escolhe a base mais adequada e pode aproveitar estrutura e
+  // linguajar das outras. XML (não Markdown) porque o conteúdo interno é
   // Markdown — a tag é a única fronteira que o modelo não confunde com a
   // resposta. Tags <modelo…> acidentais no texto do usuário são removidas para
   // não quebrar a moldura.
-  function molduraModelos(modelo) {
-    if (!modelo || !modelo.texto) return null;
-    const texto = String(modelo.texto).replace(/<\/?modelos?(_de_referencia)?\b[^>]*>/gi, "");
-    const cat = modelo.categoria
-      ? ' categoria="' + String(modelo.categoria).replace(/"/g, "") + '"'
-      : "";
-    const tit = modelo.titulo
-      ? ' titulo="' + String(modelo.titulo).replace(/"/g, "'") + '"'
-      : "";
+  function molduraModelos(modelos) {
+    if (!Array.isArray(modelos) || !modelos.length) return null;
+    const limpar = (t) => String(t).replace(/<\/?modelos?(_de_referencia)?\b[^>]*>/gi, "");
+    const partes = modelos.map((m, i) => {
+      const cat = m.categoria ? ' categoria="' + String(m.categoria).replace(/"/g, "") + '"' : "";
+      const tit = m.titulo ? ' titulo="' + String(m.titulo).replace(/"/g, "'") + '"' : "";
+      return '<modelo n="' + (i + 1) + '"' + cat + tit + ">\n" + limpar(m.texto) + "\n</modelo>";
+    });
+    const varios = modelos.length > 1;
+    const intro = varios
+      ? "Os " + modelos.length + " blocos <modelo> abaixo são peças-modelo da MESMA " +
+        "espécie que o usuário cadastrou. ANALISE todos, escolha como base o que melhor " +
+        "se ajusta a este caso e aproveite a ESTRUTURA, a ordem das seções, o fraseado e " +
+        "o tom forense — inclusive combinando trechos de LINGUAGEM (fórmulas de praxe, " +
+        "conectivos, jargão) de mais de um. Eles são de OUTROS processos.\n"
+      : "O bloco <modelo> abaixo é uma peça-modelo que o usuário cadastrou para você " +
+        "imitar a FORMA: a estrutura das seções, a ordem, o fraseado e o tom forense. " +
+        "Ela é de OUTRO processo.\n";
     return {
       type: "text",
       text:
         "<modelos_de_referencia>\n" +
-        "O bloco <modelo> abaixo é uma peça-modelo que o usuário cadastrou para você " +
-        "imitar APENAS a FORMA: a estrutura das seções, a ordem, o fraseado e o tom " +
-        "forense. Ela é de OUTRO processo.\n" +
-        "REGRA ABSOLUTA: não copie NENHUM fato do modelo — nomes de partes, números, " +
+        intro +
+        "REGRA ABSOLUTA: não copie NENHUM fato dos modelos — nomes de partes, números, " +
         "datas, valores, endereços, dispositivos legais, fundamentos ou trechos " +
-        "específicos. Todo o conteúdo da minuta sai EXCLUSIVAMENTE das peças deste " +
-        "processo, anexadas em seguida. Se o modelo trouxer um dado que não conste " +
-        "dessas peças, use [COMPLETAR: …] no lugar. O modelo é a forma; os autos são " +
-        "o conteúdo.\n" +
-        "<modelo" +
-        cat +
-        tit +
-        ">\n" +
-        texto +
-        "\n</modelo>\n" +
-        "</modelos_de_referencia>",
+        "específicos do caso. Aproveite só a forma e a linguagem. Todo o conteúdo da " +
+        "minuta sai EXCLUSIVAMENTE das peças deste processo, anexadas em seguida. Se um " +
+        "modelo trouxer um dado que não conste dessas peças, use [COMPLETAR: …] no lugar. " +
+        "Os modelos são a forma; os autos são o conteúdo.\n" +
+        partes.join("\n") +
+        "\n</modelos_de_referencia>",
     };
   }
 
-  panel.onMinuta(async (text, selectedIds, modelo) => {
+  panel.onMinuta(async (text, selectedIds, modelos) => {
     if (busy) return;
     if (selectedIds.length === 0) {
       panel.setStatus("Marque as peças que devem embasar a minuta.");
@@ -1512,12 +1516,19 @@
     panel.lockInput(true);
 
     const instrucao = (text && text.trim()) || INSTRUCAO_MINUTA_PADRAO;
-    const molduraBloco = molduraModelos(modelo);
+    const molduraBloco = molduraModelos(modelos);
+    const catModelos =
+      molduraBloco && typeof MLIB !== "undefined"
+        ? MLIB.rotuloCategoria(modelos[0].categoria)
+        : "";
     panel.addMessage(
       "user",
       "📝 Gerar minuta: " +
         instrucao +
-        (molduraBloco ? "\n\n📚 Seguindo o modelo: " + (modelo.titulo || "sem título") : ""),
+        (molduraBloco
+          ? "\n\n📚 Seguindo " + modelos.length + " modelo(s) de referência" +
+            (catModelos ? " — " + catModelos : "")
+          : ""),
       selectedIds.map((id) => metaDe(id).titulo)
     );
     let assistantEl = null;
@@ -1540,8 +1551,9 @@
       // peças, no prefixo cacheado, e o reforço na instrução volta a amarrar
       // "forma do modelo, fatos das peças".
       const reforcoModelo = molduraBloco
-        ? " Siga a ESTRUTURA e o estilo do modelo de referência fornecido no início," +
-          " mas com os FATOS exclusivamente das peças deste processo."
+        ? " Baseie a FORMA (estrutura, seções, linguagem) nos modelos de referência" +
+          " fornecidos no início — escolhendo o mais adequado e aproveitando o linguajar" +
+          " dos demais —, mas com os FATOS exclusivamente das peças deste processo."
         : "";
       const messages = prepararEnvio(
         [

--- a/src/help.html
+++ b/src/help.html
@@ -251,9 +251,10 @@
         <p><em>A minuta é uma sugestão de trabalho, não um ato: revise o texto e confira cada
         citação nos autos antes de usar. Onde faltar informação nas peças, o modelo deixa uma
         marca <code>[COMPLETAR: …]</code> para você preencher.</em></p>
-        <p><strong>📚 Modelos:</strong> cadastre suas peças-modelo (sentenças, decisões,
-        despachos, ofícios…) por categoria no botão <strong>Modelos</strong> — pode cadastrar
-        <strong>várias</strong> de cada espécie. Ao ligar o modo minuta, escolha a categoria em
+        <p><strong>📚 Modelos</strong> <em>(disponível nos modelos de 1 milhão de tokens —
+        Sonnet 5 da Anthropic e os Gemini Flash; some no Haiku, cuja janela é menor)</em>:
+        cadastre suas peças-modelo (sentenças, decisões, despachos, ofícios…) por categoria no
+        botão <strong>Modelos</strong> — pode cadastrar <strong>várias</strong> de cada espécie. Ao ligar o modo minuta, escolha a categoria em
         <strong>Seguir modelos</strong>: o assistente recebe as suas peças-modelo daquela
         espécie, segue a <strong>estrutura</strong> e o estilo da mais adequada ao caso e pode
         aproveitar o linguajar das outras — mas os fatos continuam saindo só das peças do

--- a/src/help.html
+++ b/src/help.html
@@ -251,6 +251,13 @@
         <p><em>A minuta é uma sugestão de trabalho, não um ato: revise o texto e confira cada
         citação nos autos antes de usar. Onde faltar informação nas peças, o modelo deixa uma
         marca <code>[COMPLETAR: …]</code> para você preencher.</em></p>
+        <p><strong>📚 Modelos:</strong> cadastre suas peças-modelo (sentenças, decisões,
+        despachos, ofícios…) por categoria no botão <strong>Modelos</strong>. Ao ligar o modo
+        minuta, escolha um em <strong>Seguir modelo</strong> e o assistente imita a
+        <strong>estrutura</strong> e o estilo dele — os fatos continuam saindo só das peças do
+        processo em tela, nunca do modelo. Os modelos ficam só neste navegador; se você colar
+        uma peça real, ela pode ter dados de outro processo — use <strong>excluir</strong> na
+        biblioteca quando quiser removê-la.</p>
       </div>
 
       <div class="warn-box">

--- a/src/help.html
+++ b/src/help.html
@@ -252,10 +252,12 @@
         citação nos autos antes de usar. Onde faltar informação nas peças, o modelo deixa uma
         marca <code>[COMPLETAR: …]</code> para você preencher.</em></p>
         <p><strong>📚 Modelos:</strong> cadastre suas peças-modelo (sentenças, decisões,
-        despachos, ofícios…) por categoria no botão <strong>Modelos</strong>. Ao ligar o modo
-        minuta, escolha um em <strong>Seguir modelo</strong> e o assistente imita a
-        <strong>estrutura</strong> e o estilo dele — os fatos continuam saindo só das peças do
-        processo em tela, nunca do modelo. Os modelos ficam só neste navegador; se você colar
+        despachos, ofícios…) por categoria no botão <strong>Modelos</strong> — pode cadastrar
+        <strong>várias</strong> de cada espécie. Ao ligar o modo minuta, escolha a categoria em
+        <strong>Seguir modelos</strong>: o assistente recebe as suas peças-modelo daquela
+        espécie, segue a <strong>estrutura</strong> e o estilo da mais adequada ao caso e pode
+        aproveitar o linguajar das outras — mas os fatos continuam saindo só das peças do
+        processo em tela, nunca dos modelos. Os modelos ficam só neste navegador; se você colar
         uma peça real, ela pode ter dados de outro processo — use <strong>excluir</strong> na
         biblioteca quando quiser removê-la.</p>
       </div>

--- a/src/modelos.js
+++ b/src/modelos.js
@@ -1,0 +1,145 @@
+// ---------------------------------------------------------------------------
+// PJe IA — biblioteca de MODELOS do usuário (peças-modelo para a minuta).
+//
+// Irmão do PLIB (prompts.js), com duas diferenças de propósito:
+//  1. Persiste em chrome.storage.LOCAL, não sync. Um modelo é uma peça inteira
+//     (sentença, decisão, ofício…) — facilmente dezenas de KB, muito acima dos
+//     8.192 B/item do sync. Local aguenta ~10 MB no total; perde-se o
+//     espelhamento entre dispositivos (custo aceito).
+//  2. Cada item tem CATEGORIA (a espécie do ato) e DESCRIÇÃO, além de
+//     título + texto: a categoria é o que a minuta usa para escolher, na hora
+//     de redigir, qual modelo trazer como referência de forma.
+//
+// Chave "modelo:<id>". ISTO GRAVA TEXTO DO USUÁRIO (possivelmente trecho de
+// outros processos) NO DISCO — daí a nota no PRIVACY.md e a exclusão fácil.
+// ---------------------------------------------------------------------------
+const MLIB = (() => {
+  const AREA = "local"; // único ponto de troca local/sync
+  const PREFIXO = "modelo:";
+  // Teto por modelo: puramente uma barreira de sanidade (o request da minuta
+  // já carrega os autos inteiros; um modelo gigante só desperdiça tokens). O
+  // local não tem cota por item, então isto é escolha de UX, não da API.
+  const TETO_BYTES = 60000;
+
+  // Espécies de ato que o usuário cadastra. `valor` é o que fica gravado e
+  // casa com a detecção da minuta (content.js/panel.js); `rotulo` é a UI.
+  // A ordem é a de exibição no seletor e no <optgroup>.
+  const CATEGORIAS = [
+    { valor: "despacho", rotulo: "Despachos" },
+    { valor: "sentenca", rotulo: "Sentenças" },
+    { valor: "decisao", rotulo: "Decisões, votos e acórdãos" },
+    { valor: "ata", rotulo: "Atas de audiência" },
+    { valor: "oficio", rotulo: "Ofícios" },
+    { valor: "mandado", rotulo: "Mandados e alvarás" },
+    { valor: "outro", rotulo: "Outros" },
+  ];
+
+  function rotuloCategoria(v) {
+    const c = CATEGORIAS.find((x) => x.valor === v);
+    return c ? c.rotulo : "Outros";
+  }
+
+  function categoriaValida(v) {
+    return CATEGORIAS.some((x) => x.valor === v);
+  }
+
+  function area() {
+    return chrome.storage[AREA];
+  }
+
+  function novoId() {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      return Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 10);
+    }
+  }
+
+  // Bytes REAIS (UTF-8) — .length mentiria com o texto jurídico acentuado.
+  function bytesDe(m) {
+    try {
+      return new TextEncoder().encode(PREFIXO + m.id + JSON.stringify(m)).length;
+    } catch {
+      return Infinity;
+    }
+  }
+
+  function tamanhoOk(m) {
+    return bytesDe(m) <= TETO_BYTES;
+  }
+
+  // cb(modelos) — sempre chamada, com [] em qualquer falha (harness sem
+  // storage, contexto invalidado…): a UI nunca pode quebrar por causa daqui.
+  function listar(cb) {
+    try {
+      area().get(null, (all) => {
+        const out = [];
+        for (const k in all || {}) {
+          if (k.startsWith(PREFIXO) && all[k] && all[k].id) out.push(all[k]);
+        }
+        out.sort((a, b) =>
+          String(a.titulo || "").localeCompare(String(b.titulo || ""), "pt-BR")
+        );
+        cb(out);
+      });
+    } catch {
+      cb([]);
+    }
+  }
+
+  // cb(erro) — string amigável ou null. Valida o teto ANTES do set e checa
+  // chrome.runtime.lastError (cota total do local): nunca falha mudo.
+  function salvar(m, cb) {
+    if (!tamanhoOk(m)) {
+      cb("o modelo excede o limite de " + Math.round(TETO_BYTES / 1000) + " mil caracteres — encurte o texto.");
+      return;
+    }
+    try {
+      area().set({ [PREFIXO + m.id]: m }, () => {
+        cb(chrome.runtime.lastError ? chrome.runtime.lastError.message : null);
+      });
+    } catch (e) {
+      cb(String((e && e.message) || e));
+    }
+  }
+
+  function excluir(id, cb) {
+    try {
+      area().remove(PREFIXO + id, () => {
+        if (cb) cb(chrome.runtime.lastError ? chrome.runtime.lastError.message : null);
+      });
+    } catch (e) {
+      if (cb) cb(String((e && e.message) || e));
+    }
+  }
+
+  // Re-lista a cada mudança na própria aba ou em outra. Filtra a área "local"
+  // e o prefixo "modelo:" para NÃO colidir com o storage.onChanged do
+  // content.js (config) nem com o do PLIB (área "sync").
+  function aoMudar(cb) {
+    try {
+      chrome.storage.onChanged.addListener((ch, areaName) => {
+        if (areaName !== AREA) return;
+        if (!Object.keys(ch).some((k) => k.startsWith(PREFIXO))) return;
+        listar(cb);
+      });
+    } catch {
+      /* sem storage (harness): sem propagação, a lista local segue valendo */
+    }
+  }
+
+  return {
+    listar,
+    salvar,
+    excluir,
+    tamanhoOk,
+    bytesDe,
+    aoMudar,
+    novoId,
+    CATEGORIAS,
+    rotuloCategoria,
+    categoriaValida,
+    TETO_BYTES,
+    _AREA: AREA,
+  };
+})();

--- a/src/panel.css
+++ b/src/panel.css
@@ -1057,12 +1057,12 @@
   background: #e9f2f8; border-color: var(--pje); color: var(--text);
   font-weight: 600; box-shadow: inset 0 0 0 1px rgba(0, 120, 170, 0.35);
 }
-.btn-minuta, .btn-plib, .btn-mapa {
+.btn-minuta, .btn-plib, .btn-mapa, .btn-mlib {
   border: 1px solid var(--line); background: #fff; color: var(--muted);
   border-radius: 999px; padding: 3px 11px; font-size: var(--fs-micro); cursor: pointer;
   transition: all 0.15s;
 }
-.btn-minuta:hover, .btn-plib:hover, .btn-mapa:hover { border-color: var(--pje); color: var(--text); }
+.btn-minuta:hover, .btn-plib:hover, .btn-mapa:hover, .btn-mlib:not(:disabled):hover { border-color: var(--pje); color: var(--text); }
 .btn-minuta.on, .btn-mapa.on {
   background: #e9f2f8; border-color: var(--pje); color: var(--text);
   font-weight: 600; box-shadow: inset 0 0 0 1px rgba(0, 120, 170, 0.35);

--- a/src/panel.css
+++ b/src/panel.css
@@ -1094,6 +1094,21 @@
   border-radius: 6px;
 }
 .minutabar-x:hover, .mapabar-x:hover { background: #ddeaf2; color: var(--text); }
+/* seletor de peça-modelo: cai na própria linha da faixa (a faixa quebra) */
+.minutabar { flex-wrap: wrap; }
+.minuta-modelo {
+  flex-basis: 100%; display: flex; align-items: center; gap: 6px; padding-top: 2px;
+}
+.minuta-modelo[hidden] { display: none; }
+.minuta-modelo .mm-lab { flex: none; font-weight: 700; color: var(--pje-2); }
+.minuta-modelo-sel {
+  flex: 1; min-width: 0; font: inherit; font-size: var(--fs-meta); color: var(--text);
+  border: 1px solid rgba(0, 120, 170, 0.35); border-radius: 7px;
+  padding: 4px 8px; background: #fff; cursor: pointer;
+}
+.minuta-modelo-sel:focus {
+  outline: none; border-color: var(--pje); box-shadow: 0 0 0 3px rgba(0, 120, 170, 0.15);
+}
 /* o botão Enviar vira "✍️ Gerar minuta" / "🧠 Gerar mapa" — halo azul para
    marcar a mudança (a classe .docx é histórica; vale para os dois modos) */
 .send.docx { box-shadow: 0 0 0 3px rgba(0, 120, 170, 0.28); }
@@ -1232,6 +1247,22 @@
   background: linear-gradient(180deg, var(--pje), var(--pje-2)); color: #fff;
   border: none; border-radius: 8px; padding: 7px 16px; font-weight: 700;
   cursor: pointer; font-family: inherit;
+}
+/* Modelos de peças (.mlib): reaproveita todo o visual do .plib — só o próprio */
+.mlib-form select {
+  font: inherit; font-size: var(--fs-ui); color: var(--text);
+  border: 1px solid var(--line); border-radius: 8px; padding: 7px 10px;
+  outline: none; background: #fff; cursor: pointer;
+}
+.mlib-form select:focus {
+  border-color: var(--pje); box-shadow: 0 0 0 3px rgba(0, 120, 170, 0.15);
+}
+/* etiqueta da categoria na linha do modelo */
+.mlib-cat {
+  display: inline-block; margin-right: 6px; padding: 0 6px; border-radius: 6px;
+  background: #e2eef5; color: var(--pje-2); font-size: var(--fs-nano);
+  font-weight: 700; text-transform: uppercase; letter-spacing: 0.02em;
+  vertical-align: middle;
 }
 
 /* ---------- Raciocínio (thinking) colapsável ---------- */

--- a/src/panel.js
+++ b/src/panel.js
@@ -397,7 +397,7 @@ var PjePanel = (function () {
                   <button class="btn-minuta" title="Liga o modo minuta: a instrução aparece no campo (edite à vontade) e o botão Enviar vira “Gerar minuta” — a resposta abre num editor de texto, em nova aba, de onde você copia para o PJe, baixa em Word (.docx) ou imprime.">📝 Minutar</button>
                   <button class="btn-mapa" title="Liga o modo mapa mental: a instrução aparece no campo (edite à vontade) e o botão Enviar vira “Gerar mapa” — a resposta abre num mapa mental interativo, em nova aba.">🧠 Mapa mental</button>
                   <button class="btn-plib" title="Seus prompts salvos: crie instruções reutilizáveis (título + texto) e insira-as na conversa digitando “/” no início do campo de mensagem. Sincronizam entre navegadores logados na mesma conta Google.">✦ Prompts</button>
-                  <button class="btn-mlib" title="Seus modelos de peças (sentenças, decisões, despachos, ofícios…): cadastre peças-modelo por categoria e, ao gerar uma minuta, escolha um para o assistente seguir a ESTRUTURA e o estilo — os fatos continuam saindo só das peças do processo.">📚 Modelos</button>
+                  <button class="btn-mlib" title="Seus modelos de peças (sentenças, decisões, despachos, ofícios…): cadastre várias por categoria e, ao gerar uma minuta, escolha a categoria para o assistente seguir a estrutura e o estilo dos seus modelos — os fatos continuam saindo só das peças do processo.">📚 Modelos</button>
                 </div>
                 <div class="metarow">
                   <div class="gauge" hidden title="${GAUGE_TITLE}">
@@ -2059,6 +2059,7 @@ var PjePanel = (function () {
     // Ao contrário do prompt, um modelo não é despejado no textarea: ele só
     // acompanha o turno da minuta.
     const btnMlib = $(".btn-mlib");
+    const BTN_MLIB_TITLE_ON = btnMlib ? btnMlib.title : ""; // título de HTML (reusado ao reabilitar)
     const mlibEl = $(".mlib");
     const mlibCard = $(".mlib-card");
     const mlibListEl = $(".mlib-list");
@@ -2144,6 +2145,10 @@ var PjePanel = (function () {
       }
       if (anterior && comModelo.has(anterior)) minutaModeloSel.value = anterior;
       else if (preselCat && comModelo.has(preselCat)) minutaModeloSel.value = preselCat;
+      // sem categoria detectada e só UMA categoria com modelos: pré-seleciona
+      // essa — a feature "acontece" sem exigir um clique a mais (o usuário
+      // ainda pode voltar para "nenhum")
+      else if (comModelo.size === 1) minutaModeloSel.value = comModelo.values().next().value;
       else minutaModeloSel.value = "";
     }
 
@@ -2195,11 +2200,20 @@ var PjePanel = (function () {
     }
 
     // Liga/desliga toda a feature de modelos conforme a janela do modelo ativo
-    // (1M tokens). Esconde o botão do CRUD, fecha o modal se aberto e atualiza
-    // o seletor da minuta.
+    // (1M tokens). Em vez de SUMIR nos menores (o usuário ficaria sem saber por
+    // quê), o botão do CRUD fica DESABILITADO com tooltip explicando; o seletor
+    // da minuta some (o botão já é a explicação) e o modal fecha se aberto.
+    const BTN_MLIB_TITLE_OFF =
+      "A biblioteca de modelos está disponível apenas nos modelos de 1 milhão de tokens " +
+      "(Sonnet 5 da Anthropic, Gemini Flash). Troque o modelo nas opções para usá-la.";
     function setModelosHabilitado(on) {
       modelosHabilitado = !!on;
-      if (btnMlib) btnMlib.hidden = !temMlib || !modelosHabilitado;
+      if (btnMlib) {
+        btnMlib.hidden = !temMlib; // some só no harness sem MLIB
+        btnMlib.disabled = temMlib && !modelosHabilitado;
+        if (temMlib && !modelosHabilitado) btnMlib.title = BTN_MLIB_TITLE_OFF;
+        else if (temMlib) btnMlib.title = BTN_MLIB_TITLE_ON;
+      }
       if (!modelosHabilitado && mlibEl && !mlibEl.hidden) fecharMlib();
       if (minutaMode) atualizarSeletorMinuta(true);
     }

--- a/src/panel.js
+++ b/src/panel.js
@@ -2281,7 +2281,7 @@ var PjePanel = (function () {
       mlibListEl.innerHTML = "";
       if (!modelosLib.length) {
         mlibListEl.innerHTML =
-          '<div class="plib-empty">Nenhum modelo cadastrado ainda.<br>Clique em <b>✚ Novo</b> para cadastrar sua primeira peça-modelo — depois, ao gerar uma minuta, escolha-a em <b>Seguir modelo</b>.</div>';
+          '<div class="plib-empty">Nenhum modelo cadastrado ainda.<br>Clique em <b>✚ Novo</b> para cadastrar sua primeira peça-modelo — depois, ao gerar uma minuta, escolha a categoria em <b>Seguir modelos</b>.</div>';
         return;
       }
       for (const m of modelosLib) {

--- a/src/panel.js
+++ b/src/panel.js
@@ -2076,6 +2076,11 @@ var PjePanel = (function () {
     let mlibEditId = null;
     let mlibIdNovo = "";
     let mlibDelArm = null;
+    // A biblioteca de modelos só faz sentido em modelos de 1M tokens (a minuta
+    // manda os autos inteiros + vários modelos): setModelosHabilitado, chamado
+    // pelo content.js quando as caps chegam, desliga a feature nos menores
+    // (Haiku). Começa true para não sumir no harness de teste (sem caps).
+    let modelosHabilitado = true;
 
     // MLIB é content script carregado antes deste; o harness de teste pode não
     // incluí-lo — sem ele a feature some em silêncio, nada quebra.
@@ -2176,16 +2181,27 @@ var PjePanel = (function () {
       return out;
     }
 
-    // Mostra/esconde e popula o seletor conforme o modo minuta e a existência
-    // de modelos. Chamada por setMinutaMode e pelo aoMudar do MLIB.
+    // Mostra/esconde e popula o seletor conforme o modo minuta, a existência de
+    // modelos e o modelo ativo (só 1M). Chamada por setMinutaMode, pelo aoMudar
+    // do MLIB e por setModelosHabilitado.
     function atualizarSeletorMinuta(on) {
       if (!minutaModeloWrap) return;
-      if (!on || !temMlib || !modelosLib.length) {
+      if (!on || !temMlib || !modelosHabilitado || !modelosLib.length) {
         minutaModeloWrap.hidden = true;
         return;
       }
       popularSeletorModelos(detectarCategoria(inEl.value));
       minutaModeloWrap.hidden = false;
+    }
+
+    // Liga/desliga toda a feature de modelos conforme a janela do modelo ativo
+    // (1M tokens). Esconde o botão do CRUD, fecha o modal se aberto e atualiza
+    // o seletor da minuta.
+    function setModelosHabilitado(on) {
+      modelosHabilitado = !!on;
+      if (btnMlib) btnMlib.hidden = !temMlib || !modelosHabilitado;
+      if (!modelosHabilitado && mlibEl && !mlibEl.hidden) fecharMlib();
+      if (minutaMode) atualizarSeletorMinuta(true);
     }
 
     // ----- Gerenciador de modelos (modal .mlib) -----
@@ -2811,6 +2827,9 @@ var PjePanel = (function () {
       onMapa(cb) {
         mapaCb = cb;
       },
+      // Habilita a biblioteca de modelos só nos modelos de 1M tokens (chamada
+      // pelo content.js quando as caps chegam/mudam).
+      setModelosHabilitado,
       // Resultado do mapa mental: em vez do markdown cru (longo e repetitivo)
       // a bolha vira um card com as ações, e o texto fica num <details>
       // recolhido. O card é escrito no __body da bolha — depois disso NÃO se

--- a/src/panel.js
+++ b/src/panel.js
@@ -397,6 +397,7 @@ var PjePanel = (function () {
                   <button class="btn-minuta" title="Liga o modo minuta: a instrução aparece no campo (edite à vontade) e o botão Enviar vira “Gerar minuta” — a resposta abre num editor de texto, em nova aba, de onde você copia para o PJe, baixa em Word (.docx) ou imprime.">📝 Minutar</button>
                   <button class="btn-mapa" title="Liga o modo mapa mental: a instrução aparece no campo (edite à vontade) e o botão Enviar vira “Gerar mapa” — a resposta abre num mapa mental interativo, em nova aba.">🧠 Mapa mental</button>
                   <button class="btn-plib" title="Seus prompts salvos: crie instruções reutilizáveis (título + texto) e insira-as na conversa digitando “/” no início do campo de mensagem. Sincronizam entre navegadores logados na mesma conta Google.">✦ Prompts</button>
+                  <button class="btn-mlib" title="Seus modelos de peças (sentenças, decisões, despachos, ofícios…): cadastre peças-modelo por categoria e, ao gerar uma minuta, escolha um para o assistente seguir a ESTRUTURA e o estilo — os fatos continuam saindo só das peças do processo.">📚 Modelos</button>
                 </div>
                 <div class="metarow">
                   <div class="gauge" hidden title="${GAUGE_TITLE}">
@@ -413,6 +414,10 @@ var PjePanel = (function () {
               <div class="minutabar" hidden>
                 <span class="docxbar-t">📝 <b>Modo minuta ligado</b> — revise a instrução abaixo e clique em <b>Gerar minuta</b>: a resposta abre num editor, em nova aba, pronta para revisar e levar ao PJe.</span>
                 <button class="minutabar-x" title="Cancelar a geração da minuta (Esc)">✕</button>
+                <label class="minuta-modelo" hidden>
+                  <span class="mm-lab">Seguir modelo:</span>
+                  <select class="minuta-modelo-sel" title="Escolha uma peça-modelo cadastrada para o assistente imitar a estrutura e o estilo — os fatos continuam vindo só das peças do processo."></select>
+                </label>
               </div>
               <div class="mapabar" hidden>
                 <span class="docxbar-t">🧠 <b>Modo mapa mental ligado</b> — revise a instrução abaixo e clique em <b>Gerar mapa</b>: a resposta vira um mapa mental interativo, que abre em nova aba.</span>
@@ -443,6 +448,28 @@ var PjePanel = (function () {
               <div class="plib-form-acts">
                 <button class="plib-cancel">Cancelar</button>
                 <button class="plib-save">Salvar</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="mlib plib" hidden>
+          <div class="mlib-card plib-card" role="dialog" aria-modal="true" aria-label="Modelos de peças" tabindex="-1">
+            <div class="plib-hd">
+              <span class="t">📚 Modelos de peças</span>
+              <button class="mlib-new plib-new">✚ Novo</button>
+              <button class="mlib-close plib-close" title="Fechar (Esc)" aria-label="Fechar o gerenciador de modelos">✕</button>
+            </div>
+            <div class="mlib-list plib-list"></div>
+            <div class="mlib-form plib-form" hidden>
+              <input type="text" class="mlib-ft" maxlength="80" placeholder="Título do modelo (ex.: Sentença de improcedência — dano moral)" aria-label="Título do modelo">
+              <select class="mlib-fc" aria-label="Categoria do modelo"></select>
+              <input type="text" class="mlib-fd" maxlength="120" placeholder="Descrição — opcional (quando usar este modelo)" aria-label="Descrição do modelo">
+              <textarea class="mlib-fx" placeholder="Cole o texto da peça-modelo — o assistente imita a ESTRUTURA e o estilo; os fatos vêm sempre das peças do processo, nunca do modelo…" aria-label="Texto do modelo"></textarea>
+              <div class="mlib-cnt plib-cnt"></div>
+              <div class="mlib-err plib-err" role="alert"></div>
+              <div class="plib-form-acts">
+                <button class="mlib-cancel plib-cancel">Cancelar</button>
+                <button class="mlib-save plib-save">Salvar</button>
               </div>
             </div>
           </div>
@@ -884,6 +911,7 @@ var PjePanel = (function () {
         ? "Instrução da minuta — edite e clique em Gerar minuta…"
         : "Pergunte sobre as peças… (@ cita uma peça)";
       if (!on) statusEl.textContent = "";
+      atualizarSeletorMinuta(on); // popula/oculta o seletor de peça-modelo
     }
     btnMinuta.addEventListener("click", () => {
       if (minutaMode) return setMinutaMode(false); // segundo clique = cancelar
@@ -2021,6 +2049,295 @@ var PjePanel = (function () {
       abrirPlib(promptsLib.length ? {} : { form: true })
     );
 
+    // ----- Biblioteca de MODELOS (peças-modelo, MLIB/storage.local) ----------
+    // Irmã do PLIB, com dois papéis: (1) o modal .mlib faz o CRUD (título,
+    // categoria, descrição, texto); (2) o seletor da .minutabar oferece, ao
+    // gerar a minuta, um modelo daquela categoria para o assistente imitar a
+    // FORMA — o texto do modelo vira uma moldura XML no request (content.js),
+    // NUNCA fonte de fatos. Ao contrário do prompt, um modelo não é despejado
+    // no textarea: ele só acompanha o turno da minuta.
+    const btnMlib = $(".btn-mlib");
+    const mlibEl = $(".mlib");
+    const mlibCard = $(".mlib-card");
+    const mlibListEl = $(".mlib-list");
+    const mlibForm = $(".mlib-form");
+    const mlibFT = $(".mlib-ft");
+    const mlibFC = $(".mlib-fc");
+    const mlibFD = $(".mlib-fd");
+    const mlibFX = $(".mlib-fx");
+    const mlibCnt = $(".mlib-cnt");
+    const mlibErr = $(".mlib-err");
+    const minutaModeloWrap = $(".minuta-modelo");
+    const minutaModeloSel = $(".minuta-modelo-sel");
+
+    let modelosLib = []; // espelho ordenado de MLIB.listar
+    let mlibEditId = null;
+    let mlibIdNovo = "";
+    let mlibDelArm = null;
+
+    // MLIB é content script carregado antes deste; o harness de teste pode não
+    // incluí-lo — sem ele a feature some em silêncio, nada quebra.
+    const temMlib = typeof MLIB !== "undefined";
+    if (temMlib) {
+      // popula o <select> de categoria do form uma única vez
+      for (const c of MLIB.CATEGORIAS) {
+        const op = document.createElement("option");
+        op.value = c.valor;
+        op.textContent = c.rotulo;
+        mlibFC.appendChild(op);
+      }
+      MLIB.listar((ms) => {
+        modelosLib = ms;
+        if (minutaMode) atualizarSeletorMinuta(true);
+      });
+      MLIB.aoMudar((ms) => {
+        modelosLib = ms;
+        if (!mlibEl.hidden) renderMlibList();
+        if (minutaMode) atualizarSeletorMinuta(true);
+      });
+    } else {
+      if (btnMlib) btnMlib.hidden = true;
+      if (minutaModeloWrap) minutaModeloWrap.hidden = true;
+    }
+
+    // Detecção da espécie a partir da instrução, para PRÉ-selecionar a
+    // categoria no seletor. Espelha o agrupamento de MINUTA_ESPECIE
+    // (content.js); é só uma conveniência de UI (o usuário pode trocar).
+    function detectarCategoria(texto) {
+      const s = norm(String(texto || ""));
+      if (/\bsentenc/.test(s)) return "sentenca";
+      if (/\bdespacho/.test(s)) return "despacho";
+      if (/\b(decisao|decisoes|voto|acordao|acordaos|liminar|tutela)\b/.test(s)) return "decisao";
+      if (/\b(ata|audiencia|termo de audiencia)\b/.test(s)) return "ata";
+      if (/\boficio/.test(s)) return "oficio";
+      if (/\b(mandado|alvara)\b/.test(s)) return "mandado";
+      return null;
+    }
+
+    // Reconstrói o <select> do modo minuta agrupando por categoria. Preserva a
+    // escolha MANUAL anterior; sem ela, pré-seleciona pela categoria detectada.
+    function popularSeletorModelos(preselCat) {
+      if (!minutaModeloSel) return;
+      const anterior = minutaModeloSel.value;
+      minutaModeloSel.innerHTML = "";
+      const nenhum = document.createElement("option");
+      nenhum.value = "";
+      nenhum.textContent = "— nenhum (estilo padrão) —";
+      minutaModeloSel.appendChild(nenhum);
+      let preselId = "";
+      for (const cat of MLIB.CATEGORIAS) {
+        const doGrupo = modelosLib.filter((m) => (m.categoria || "outro") === cat.valor);
+        if (!doGrupo.length) continue;
+        const og = document.createElement("optgroup");
+        og.label = cat.rotulo;
+        for (const m of doGrupo) {
+          const op = document.createElement("option");
+          op.value = m.id;
+          op.textContent = m.titulo;
+          og.appendChild(op);
+          if (!preselId && preselCat && cat.valor === preselCat) preselId = m.id;
+        }
+        minutaModeloSel.appendChild(og);
+      }
+      if (anterior && modelosLib.some((m) => m.id === anterior)) minutaModeloSel.value = anterior;
+      else minutaModeloSel.value = preselId;
+    }
+
+    // Mostra/esconde e popula o seletor conforme o modo minuta e a existência
+    // de modelos. Chamada por setMinutaMode e pelo aoMudar do MLIB.
+    function atualizarSeletorMinuta(on) {
+      if (!minutaModeloWrap) return;
+      if (!on || !temMlib || !modelosLib.length) {
+        minutaModeloWrap.hidden = true;
+        return;
+      }
+      popularSeletorModelos(detectarCategoria(inEl.value));
+      minutaModeloWrap.hidden = false;
+    }
+
+    // Modelo escolhido para a minuta pendente (ou null). Lido ANTES de
+    // setMinutaMode(false) no doSend — depois o wrap fica oculto.
+    function modeloMinutaSelecionado() {
+      if (!minutaModeloSel || !minutaModeloWrap || minutaModeloWrap.hidden) return null;
+      const id = minutaModeloSel.value;
+      return (id && modelosLib.find((m) => m.id === id)) || null;
+    }
+
+    // ----- Gerenciador de modelos (modal .mlib) -----
+    function abrirMlib(opts) {
+      opts = opts || {};
+      mlibEl.hidden = false;
+      mlibDelArm = null;
+      if (opts.form) abrirMlibForm(null);
+      else fecharMlibForm();
+      renderMlibList();
+      if (!opts.form) mlibCard.focus();
+    }
+
+    function fecharMlib() {
+      mlibEl.hidden = true;
+      fecharMlibForm();
+      inEl.focus();
+    }
+
+    function abrirMlibForm(m) {
+      mlibEditId = m ? m.id : null;
+      mlibIdNovo = m ? null : temMlib ? MLIB.novoId() : "";
+      mlibFT.value = m ? m.titulo : "";
+      mlibFC.value = m ? m.categoria || "outro" : "sentenca";
+      mlibFD.value = m ? m.descricao || "" : "";
+      mlibFX.value = m ? m.texto : "";
+      mlibErr.textContent = "";
+      mlibForm.hidden = false;
+      mlibListEl.hidden = true;
+      atualizarMlibCnt();
+      mlibFT.focus();
+    }
+
+    function fecharMlibForm() {
+      mlibEditId = null;
+      mlibForm.hidden = true;
+      mlibListEl.hidden = false;
+      mlibErr.textContent = "";
+    }
+
+    function modeloDoForm() {
+      const agora = Date.now();
+      const antigo = mlibEditId && modelosLib.find((x) => x.id === mlibEditId);
+      return {
+        id: mlibEditId || mlibIdNovo,
+        titulo: mlibFT.value.trim(),
+        categoria: mlibFC.value || "outro",
+        descricao: mlibFD.value.trim(),
+        texto: mlibFX.value.trim(),
+        criadoEm: antigo ? antigo.criadoEm : agora,
+        atualizadoEm: agora,
+      };
+    }
+
+    function atualizarMlibCnt() {
+      if (!temMlib) return;
+      const b = MLIB.bytesDe(modeloDoForm());
+      const pct = Math.min(999, Math.round((b / MLIB.TETO_BYTES) * 100));
+      mlibCnt.textContent = mlibFX.value.length + " caracteres — " + pct + "% do limite";
+      mlibCnt.classList.toggle("estouro", b > MLIB.TETO_BYTES);
+    }
+    if (temMlib) {
+      mlibFT.addEventListener("input", atualizarMlibCnt);
+      mlibFD.addEventListener("input", atualizarMlibCnt);
+      mlibFX.addEventListener("input", atualizarMlibCnt);
+      // Enter no título salva (o texto é multilinha e mantém o Enter próprio)
+      mlibFT.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          salvarMlibForm();
+        }
+      });
+    }
+
+    function renderMlibList() {
+      mlibDelArm = null;
+      mlibListEl.innerHTML = "";
+      if (!modelosLib.length) {
+        mlibListEl.innerHTML =
+          '<div class="plib-empty">Nenhum modelo cadastrado ainda.<br>Clique em <b>✚ Novo</b> para cadastrar sua primeira peça-modelo — depois, ao gerar uma minuta, escolha-a em <b>Seguir modelo</b>.</div>';
+        return;
+      }
+      for (const m of modelosLib) {
+        const row = document.createElement("div");
+        row.className = "plib-row";
+        row.dataset.id = m.id;
+        const prev = m.descricao || previaDe(m.texto);
+        row.innerHTML =
+          '<div class="plib-info"><span class="plib-t" title="' + escapeHtml(m.titulo) + '">' +
+          '<span class="mlib-cat">' + escapeHtml(MLIB.rotuloCategoria(m.categoria)) + "</span>" +
+          escapeHtml(m.titulo) +
+          '</span><span class="plib-prev">' + escapeHtml(prev) + "</span></div>" +
+          '<div class="plib-acts">' +
+          '<button class="mlib-edit" title="Editar este modelo">editar</button>' +
+          '<button class="mlib-del plib-del" title="Excluir este modelo">excluir</button></div>';
+        mlibListEl.appendChild(row);
+      }
+    }
+
+    // ações DELEGADAS na lista (as rows são recriadas a cada render)
+    mlibListEl.addEventListener("click", (e) => {
+      const btn = e.target.closest("button");
+      const row = e.target.closest(".plib-row");
+      if (!btn || !row) return;
+      const m = modelosLib.find((x) => x.id === row.dataset.id);
+      if (!m) return;
+      if (btn.classList.contains("mlib-edit")) {
+        abrirMlibForm(m);
+      } else if (btn.classList.contains("mlib-del")) {
+        // exclusão em DOIS cliques (nunca confirm() nativo — congela a página)
+        if (mlibDelArm !== m.id) {
+          mlibListEl.querySelectorAll(".mlib-del.arm").forEach((b) => {
+            b.textContent = "excluir";
+            b.classList.remove("arm");
+          });
+        }
+        if (mlibDelArm === m.id) {
+          mlibDelArm = null;
+          MLIB.excluir(m.id, () => {
+            modelosLib = modelosLib.filter((x) => x.id !== m.id);
+            renderMlibList();
+          });
+        } else {
+          mlibDelArm = m.id;
+          btn.textContent = "excluir?";
+          btn.classList.add("arm");
+        }
+      }
+    });
+
+    function salvarMlibForm() {
+      const m = modeloDoForm();
+      if (!m.titulo) {
+        mlibErr.textContent = "Dê um título ao modelo.";
+        mlibFT.focus();
+        return;
+      }
+      if (!m.texto) {
+        mlibErr.textContent = "Cole o texto da peça-modelo.";
+        mlibFX.focus();
+        return;
+      }
+      MLIB.salvar(m, (erro) => {
+        if (erro) {
+          mlibErr.textContent = "Não foi possível salvar: " + erro;
+          return;
+        }
+        modelosLib = modelosLib
+          .filter((x) => x.id !== m.id)
+          .concat(m)
+          .sort((a, b) => String(a.titulo).localeCompare(String(b.titulo), "pt-BR"));
+        fecharMlibForm();
+        renderMlibList();
+      });
+    }
+    if (temMlib) {
+      mlibCard.querySelector(".mlib-save").addEventListener("click", salvarMlibForm);
+      mlibCard.querySelector(".mlib-cancel").addEventListener("click", fecharMlibForm);
+      mlibCard.querySelector(".mlib-new").addEventListener("click", () => abrirMlibForm(null));
+      mlibCard.querySelector(".mlib-close").addEventListener("click", fecharMlib);
+      mlibEl.addEventListener("click", (e) => {
+        if (e.target === mlibEl) fecharMlib();
+      });
+      // Esc no modal: fecha o form (se aberto) ou o modal — e NÃO vaza para o
+      // Esc do painel (que cancelaria o modo minuta junto)
+      mlibCard.addEventListener("keydown", (e) => {
+        if (e.key !== "Escape") return;
+        e.preventDefault();
+        e.stopPropagation();
+        if (!mlibForm.hidden) fecharMlibForm();
+        else fecharMlib();
+      });
+      btnMlib.addEventListener("click", () =>
+        abrirMlib(modelosLib.length ? {} : { form: true })
+      );
+    }
+
     inEl.addEventListener("input", () => {
       autoresize();
       updateMention();
@@ -2060,8 +2377,10 @@ var PjePanel = (function () {
           statusEl.textContent = "Marque as peças que devem embasar a minuta.";
           return;
         }
+        // lê o modelo escolhido ANTES de desligar o modo (o seletor some com ele)
+        const modelo = modeloMinutaSelecionado();
         setMinutaMode(false);
-        minutaCb(t, sel);
+        minutaCb(t, sel, modelo);
         inEl.value = "";
         inEl.style.height = "auto";
         setPromptAtivo(null); // consumido no envio

--- a/src/panel.js
+++ b/src/panel.js
@@ -415,8 +415,8 @@ var PjePanel = (function () {
                 <span class="docxbar-t">📝 <b>Modo minuta ligado</b> — revise a instrução abaixo e clique em <b>Gerar minuta</b>: a resposta abre num editor, em nova aba, pronta para revisar e levar ao PJe.</span>
                 <button class="minutabar-x" title="Cancelar a geração da minuta (Esc)">✕</button>
                 <label class="minuta-modelo" hidden>
-                  <span class="mm-lab">Seguir modelo:</span>
-                  <select class="minuta-modelo-sel" title="Escolha uma peça-modelo cadastrada para o assistente imitar a estrutura e o estilo — os fatos continuam vindo só das peças do processo."></select>
+                  <span class="mm-lab">Seguir modelos:</span>
+                  <select class="minuta-modelo-sel" title="Escolha uma categoria: o assistente recebe as suas peças-modelo daquela espécie e segue a estrutura e o estilo da mais adequada ao caso — os fatos continuam vindo só das peças do processo."></select>
                 </label>
               </div>
               <div class="mapabar" hidden>
@@ -2051,11 +2051,13 @@ var PjePanel = (function () {
 
     // ----- Biblioteca de MODELOS (peças-modelo, MLIB/storage.local) ----------
     // Irmã do PLIB, com dois papéis: (1) o modal .mlib faz o CRUD (título,
-    // categoria, descrição, texto); (2) o seletor da .minutabar oferece, ao
-    // gerar a minuta, um modelo daquela categoria para o assistente imitar a
-    // FORMA — o texto do modelo vira uma moldura XML no request (content.js),
-    // NUNCA fonte de fatos. Ao contrário do prompt, um modelo não é despejado
-    // no textarea: ele só acompanha o turno da minuta.
+    // categoria, descrição, texto); (2) o seletor da .minutabar escolhe uma
+    // CATEGORIA e, ao gerar a minuta, TODAS as peças-modelo daquela espécie
+    // (até um teto) vão ao request numa moldura XML (content.js): a IA analisa,
+    // escolhe a base mais adequada e pode aproveitar estrutura e linguajar das
+    // outras — mas os FATOS saem só das peças do processo, NUNCA dos modelos.
+    // Ao contrário do prompt, um modelo não é despejado no textarea: ele só
+    // acompanha o turno da minuta.
     const btnMlib = $(".btn-mlib");
     const mlibEl = $(".mlib");
     const mlibCard = $(".mlib-card");
@@ -2114,33 +2116,64 @@ var PjePanel = (function () {
       return null;
     }
 
-    // Reconstrói o <select> do modo minuta agrupando por categoria. Preserva a
-    // escolha MANUAL anterior; sem ela, pré-seleciona pela categoria detectada.
+    // Reconstrói o <select> do modo minuta: uma opção por CATEGORIA que tenha
+    // modelos, com a contagem. Preserva a escolha MANUAL anterior; sem ela,
+    // pré-seleciona pela categoria detectada na instrução.
     function popularSeletorModelos(preselCat) {
       if (!minutaModeloSel) return;
-      const anterior = minutaModeloSel.value;
+      const anterior = minutaModeloSel.value; // valor = categoria
       minutaModeloSel.innerHTML = "";
       const nenhum = document.createElement("option");
       nenhum.value = "";
       nenhum.textContent = "— nenhum (estilo padrão) —";
       minutaModeloSel.appendChild(nenhum);
-      let preselId = "";
+      const comModelo = new Set();
       for (const cat of MLIB.CATEGORIAS) {
-        const doGrupo = modelosLib.filter((m) => (m.categoria || "outro") === cat.valor);
-        if (!doGrupo.length) continue;
-        const og = document.createElement("optgroup");
-        og.label = cat.rotulo;
-        for (const m of doGrupo) {
-          const op = document.createElement("option");
-          op.value = m.id;
-          op.textContent = m.titulo;
-          og.appendChild(op);
-          if (!preselId && preselCat && cat.valor === preselCat) preselId = m.id;
-        }
-        minutaModeloSel.appendChild(og);
+        const n = modelosLib.filter((m) => (m.categoria || "outro") === cat.valor).length;
+        if (!n) continue;
+        comModelo.add(cat.valor);
+        const op = document.createElement("option");
+        op.value = cat.valor;
+        op.textContent = cat.rotulo + " (" + n + ")";
+        minutaModeloSel.appendChild(op);
       }
-      if (anterior && modelosLib.some((m) => m.id === anterior)) minutaModeloSel.value = anterior;
-      else minutaModeloSel.value = preselId;
+      if (anterior && comModelo.has(anterior)) minutaModeloSel.value = anterior;
+      else if (preselCat && comModelo.has(preselCat)) minutaModeloSel.value = preselCat;
+      else minutaModeloSel.value = "";
+    }
+
+    // Modelos enviados por minuta: TODOS os da categoria escolhida, do mais
+    // recente ao mais antigo, até dois tetos — nº de modelos e total de
+    // caracteres (guarda de contexto: a minuta não tem pré-voo de tokens). O
+    // primeiro modelo sempre entra, mesmo acima do teto de caracteres.
+    const MODELOS_MAX_ENVIO = 12;
+    const MODELOS_TETO_CHARS = 180000; // ~45 mil tokens no total
+    function modelosMinutaSelecionados() {
+      if (!minutaModeloSel || !minutaModeloWrap || minutaModeloWrap.hidden) return [];
+      const cat = minutaModeloSel.value;
+      if (!cat) return [];
+      const doGrupo = modelosLib
+        .filter((m) => (m.categoria || "outro") === cat && m.texto)
+        .sort((a, b) => (b.atualizadoEm || 0) - (a.atualizadoEm || 0));
+      const out = [];
+      let chars = 0;
+      for (const m of doGrupo) {
+        if (out.length >= MODELOS_MAX_ENVIO) break;
+        const tam = String(m.texto).length;
+        if (out.length && chars + tam > MODELOS_TETO_CHARS) break;
+        out.push(m);
+        chars += tam;
+      }
+      // "sem cap silencioso": avisa no console quando corta modelos da categoria
+      if (doGrupo.length > out.length) {
+        try {
+          console.info(
+            "[PJe IA] minuta: enviando " + out.length + " de " + doGrupo.length +
+              " modelos da categoria (teto de contexto)."
+          );
+        } catch (e) {}
+      }
+      return out;
     }
 
     // Mostra/esconde e popula o seletor conforme o modo minuta e a existência
@@ -2153,14 +2186,6 @@ var PjePanel = (function () {
       }
       popularSeletorModelos(detectarCategoria(inEl.value));
       minutaModeloWrap.hidden = false;
-    }
-
-    // Modelo escolhido para a minuta pendente (ou null). Lido ANTES de
-    // setMinutaMode(false) no doSend — depois o wrap fica oculto.
-    function modeloMinutaSelecionado() {
-      if (!minutaModeloSel || !minutaModeloWrap || minutaModeloWrap.hidden) return null;
-      const id = minutaModeloSel.value;
-      return (id && modelosLib.find((m) => m.id === id)) || null;
     }
 
     // ----- Gerenciador de modelos (modal .mlib) -----
@@ -2377,10 +2402,10 @@ var PjePanel = (function () {
           statusEl.textContent = "Marque as peças que devem embasar a minuta.";
           return;
         }
-        // lê o modelo escolhido ANTES de desligar o modo (o seletor some com ele)
-        const modelo = modeloMinutaSelecionado();
+        // lê os modelos da categoria ANTES de desligar o modo (o seletor some)
+        const modelos = modelosMinutaSelecionados();
         setMinutaMode(false);
-        minutaCb(t, sel, modelo);
+        minutaCb(t, sel, modelos);
         inEl.value = "";
         inEl.style.height = "auto";
         setPromptAtivo(null); // consumido no envio


### PR DESCRIPTION
## O que faz

Adiciona uma **biblioteca de modelos de peças**: o usuário cadastra peças-modelo (sentenças, decisões, despachos, ofícios, atas, mandados) por categoria e, ao gerar uma minuta, escolhe um modelo para o assistente **seguir a estrutura e o estilo**. Sem RAG — apenas *few-shot* no request isolado da minuta, que já carrega os autos.

## Decisão de desenho central: anti-contaminação

Como o usuário provavelmente vai colar a peça-modelo real (com nomes, valores e datas de **outro** processo), o texto do modelo entra numa **moldura XML** `<modelos_de_referencia>` com regra dura de que serve **só de forma**: nenhum fato do modelo pode entrar na minuta, que se baseia exclusivamente nas peças do processo em tela. XML (não Markdown) porque o conteúdo interno já é Markdown — a tag é a única fronteira que o modelo não confunde com a própria resposta. Tags `<modelo…>` acidentais no texto do usuário são removidas para não quebrar a moldura.

## Mudanças

- **`src/modelos.js` (novo):** global `MLIB`, CRUD sobre `chrome.storage.local` (um item por modelo `modelo:<id>`, com categoria/descrição), irmão do `PLIB`. Local, não `sync`, porque uma peça-modelo estoura os 8 KB/item do `sync`. Registrado no `manifest.json` (antes do `panel.js`).
- **`src/panel.js`:** botão **📚 Modelos**; modal CRUD `.mlib` (reaproveita todo o visual do `.plib`, só adiciona categoria + descrição); seletor **"Seguir modelo"** na faixa da minuta, com pré-seleção da categoria detectada pela instrução (espelha o agrupamento de `MINUTA_ESPECIE`). O modelo escolhido é lido antes de desligar o modo e segue via `minutaCb(t, sel, modelo)`.
- **`src/content.js`:** `onMinuta` recebe o `modelo`; monta a moldura XML como **primeiro bloco** do content (fica no prefixo cacheado) e reforça a instrução com "forma do modelo, fatos das peças".
- **`PRIVACY.md` / `src/help.html`:** notas de que os modelos ficam no disco (`storage.local`, sem sync) e vão ao provedor só como referência de forma.

## Invariantes respeitadas

- Funciona nos **dois provedores** (Claude e Gemini): a minuta é chat comum, sem gating por nome de modelo.
- **Fonte de verdade** da seleção de peças inalterada; o modelo não é peça dos autos — vai como texto, não como `document`/`file_id`, e não é citável.
- Feature some em silêncio se `MLIB` faltar (harness sem o content script), como o `PLIB`.
- Exclusão em dois cliques, sem `confirm()` nativo; Esc em cascata no modal.

## Testes

- `node --check` em `modelos.js`, `panel.js`, `content.js` e o `manifest.json` válido.
- Teste no scratchpad (24 asserções, todas passando): CRUD do `MLIB` sobre stub de `storage.local` (salvar/listar/ordenar/excluir, teto de tamanho, prefixo de chave, nada em `sync`), a sanitização da moldura XML (remove `<modelo>`/`</modelos_de_referencia>` acidentais, **preserva** `<` e `>` comuns do texto jurídico) e a detecção de categoria.

## Como testar no PJe

Recarregar a extensão em `chrome://extensions`, abrir um processo, cadastrar um modelo em **📚 Modelos**, ligar **📝 Minutar**, escolher o modelo em **Seguir modelo** e gerar. Conferir que a minuta segue a estrutura do modelo mas cita só peças do processo em tela.
