### PR TITLE
feat: suporte ao provedor OpenAI (GPT-5.6 Luna / Terra / Sol)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 Extensão Chrome (Manifest V3, JavaScript puro, **sem build step**) que adiciona um painel
 de chat com IA à tela de autos digitais do PJe. O usuário seleciona peças do
 processo e conversa sobre elas; os PDFs são enviados diretamente à API do provedor do
-modelo escolhido — **Anthropic (Claude)** ou **Google (Gemini)**, ver a seção
-"Provedor Gemini".
+modelo escolhido — **Anthropic (Claude)**, **Google (Gemini)** ou **OpenAI (GPT)**, ver as
+seções "Provedor Gemini" e "Provedor OpenAI".
 
 ## Arquitetura
 
@@ -61,8 +61,8 @@ erro é 429/529/5xx ou queda de rede no meio do SSE (flag `retryable` posta pelo
 `claude.js`). `max_tokens` é 32000 (OBRIGATÓRIO na Anthropic; 32K é o teto de saída
 aceito por todos os modelos Claude).
 
-`MODEL_CAPS` em `background.js` governa por modelo: `provider` (anthropic|gemini),
-`contextTokens`, `maxPages` (600 nos modelos de 1M; 100 no Haiku; 1000 no Gemini),
+`MODEL_CAPS` em `background.js` governa por modelo: `provider` (anthropic|gemini|openai),
+`contextTokens`, `maxPages` (600 nos modelos de 1M; 100 no Haiku; 1000 no Gemini; 500 nos GPT),
 versões de `web_search`/`web_fetch` (variantes `_20260209` no Sonnet 5/Opus 4.8;
 básicas no Fable/Haiku), `thinking` (adaptive+summarized; omitido no Haiku) e `effort`
 (não suportado no Haiku; no Gemini vira `thinking_level`). Entradas Gemini têm ainda
@@ -140,6 +140,77 @@ quebrar:
 - countTokens Gemini: `POST /models/{model}:countTokens` com `contents` traduzidos
   (file_data/inline_data/texto; steps opacos viram texto) — aproximação aceitável, a
   guarda de 90% e o `usageReq` pós-turno corrigem.
+
+## Provedor OpenAI (Responses API)
+
+`src/openai.js` é o TERCEIRO irmão de `claude.js` (INTOCADO) e `gemini.js`: emite o MESMO
+vocabulário de eventos (`{kind:"text"|"thinking"|"citation"|"tool"|"trunc"|"final"}`) a
+partir do SSE da **Responses API** (`POST /v1/responses`, header `Authorization: Bearer`;
+GA, **sem header beta** — a API antiga `/chat/completions` NÃO é usada). `background.js`
+despacha por `providerDe(model)` (prefixo `gpt-`); `content.js` e `panel.js` só condicionam
+por **caps**, nunca por nome de modelo. Modelos: `gpt-5.6-sol` (topo, alias "GPT-5.6"),
+`gpt-5.6-terra` (equilibrado), `gpt-5.6-luna` (rápido/barato) — todos 1,05M de contexto.
+Regras que NÃO podem quebrar:
+
+- **Modo stateless obrigatório** (`store:false`): o histórico interno continua nos blocos
+  estilo Anthropic (com `__pecaId`) e `traduzirHistorico` em openai.js converte NO REQUEST —
+  o filtro de peças desmarcadas (`prepararEnvio`) funciona igual nos três provedores. O
+  system prompt vai em `instructions` (nível superior), NÃO no `input`.
+- **Itens de raciocínio criptografados**: cada item `{type:"reasoning", id, encrypted_content}`
+  da resposta é gravado no histórico como `{type:"x-openai-item", raw: item}` e devolvido
+  VERBATIM no reenvio — reasoning criptografado precisa voltar byte a byte (regra análoga ao
+  thinking assinado da Anthropic e ao `thought_signature` do Gemini). O request declara
+  `include:["reasoning.encrypted_content"]` (para o conteúdo voltar no stateless) e
+  `reasoning:{effort, summary:"auto", context:"all_turns"}`. `sanearCitacoes`/`prepararEnvio`
+  não tocam nesses blocos por construção. A ordem `[reasoning, message]` é preservada na
+  tradução — a API exige que um item reasoning seja seguido pelo item que ele produziu.
+- **effort** (o eixo que o usuário pediu para conferir): a escala da OpenAI é a MAIS RICA —
+  `none|minimal|low|medium|high|xhigh|max` (+ um eixo separado `reasoning.mode`
+  standard|pro|ultra). O suporte a `xhigh`/`max` é dependente da variante e não documentado
+  por modelo (Luna/Terra podem rejeitar com 400). `EFFORT_PARA_OPENAI` em background.js mapeia
+  os três níveis da extensão para o subconjunto COMUM `low/medium/high` (aceito por todos os
+  provedores e todas as variantes 5.6); expor `xhigh`/`max` seria só aqui, provavelmente só no
+  Sol. Anthropic/Gemini/OpenAI compartilham low/medium/high.
+- **usage normalizado** para as 4 categorias da Anthropic em openai.js
+  (`input = input_tokens − cached`; `cache_read = input_tokens_details.cached_tokens`;
+  `cache_creation = 0`; `output = output_tokens`, que já inclui os tokens de raciocínio) —
+  custo, tooltip e gauge funcionam sem mudança. `custoUsdDe` usa `preco.cacheRead` (10% do
+  input; cache automático, sem cobrança de gravação).
+- **Uploads por provedor**: a Files API da OpenAI (`POST /v1/files`, `purpose:"user_data"`)
+  devolve um `file_id` que persiste na conta (não expira por padrão) — o cache de sessão usa
+  namespace `ofile:` (sem validação de expiração, ao contrário do `gfile:` do Gemini), e cada
+  peça em `docsCache` guarda `d.fileProvider`: um `file_id` da OpenAI nunca entra num request
+  Anthropic/Gemini (e vice-versa; `montarBlocos`/`subirPecas` conferem). PDF: ≤ 50 MB/arquivo
+  e ≤ 50 MB somados por request; fallback base64 com teto `MAX_TOTAL_B64_CHARS_OPENAI` (40 MB).
+- **Sem citações por página na OpenAI** (`citacoesNativas:false`, igual ao Gemini): o system
+  prompt alternativo (`SYSTEM_PROMPT_CIT_TEXTUAL`) manda citar peça e folha no próprio texto;
+  `panel.setModoCitacoes("textual")` mostra o `ⓘ`. Annotations `url_citation` da busca viram
+  citações web normais (`web_search_result_location`), ao vivo pelo evento
+  `response.output_text.annotation.added`; `file_citation` é ignorada (sem página).
+- **Busca**: toggle Jurisprudência na OpenAI declara `[{type:"web_search"}]` — sem
+  `allowed_domains` (a priorização de fontes .jus.br vai por instrução no system prompt, como
+  no Gemini).
+- **Troca de provedor no meio da conversa é BLOQUEADA** (`conversaProvider`): o histórico de
+  um provedor não roda no outro (raciocínio assinado/criptografado). `ALERTA_TROCA_PROVEDOR`
+  cobre os três; "Nova conversa" resolve.
+- **Sem pause_turn na OpenAI**: o loop de continuações de `executarTurno` sai na 1ª iteração;
+  retry transitório (429/5xx, `err.retryable`) funciona igual. Stream que termina SEM
+  `response.completed`/`response.incomplete`, ou eventos `response.failed`/`error`, LANÇAM erro
+  retryable — resposta parcial nunca passa por completa. `response.incomplete` com
+  `reason:max_output_tokens` vira `trunc` + stopReason `max_tokens`; recusa (`content_filter`
+  ou content-part `refusal`) vira `refusal`.
+- **Teto de saída na OpenAI: `max_output_tokens = 65536` SEMPRE explícito** — generoso (folga
+  enorme para minuta + resumo de raciocínio; o máximo dos 5.6 é 128.000) e limitado para custo
+  previsível. NUNCA repassar o `req.max_tokens` de 32000 do caminho Anthropic. Cache: só
+  automático (implicit) — `cache_control` não é gravado nos blocos quando o provedor não é
+  anthropic (`montarBlocos` só marca o breakpoint no Anthropic).
+- **Config**: chave em `chrome.storage.local.openaiApiKey` (Anthropic = `apiKey`, Gemini =
+  `geminiApiKey`); `chaveDe(cfg, provider)` escolhe e dá erro claro. popup/options têm os TRÊS
+  campos e uma lista única de modelos com `<optgroup>`; o chip e o `refreshKey` olham a chave do
+  provedor do modelo selecionado. `manifest.json` inclui `https://api.openai.com/*`.
+- countTokens OpenAI: `POST /v1/responses/input_tokens` (mesmo corpo do `/responses`) →
+  `{input_tokens}` — endpoint dedicado e exato (conta arquivos/imagens/tools), análogo ao
+  count_tokens da Anthropic. A guarda de 90% fica precisa.
 
 ## Invariantes importantes
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -10,14 +10,14 @@ descreve, de forma completa, quais dados a extensão trata, para onde eles vão 
 **Resumo em uma frase:** a extensão não tem servidor próprio, não coleta telemetria e o
 desenvolvedor **nunca tem acesso a nenhum dado seu** — os documentos que você selecionar
 são enviados diretamente do seu navegador à API do provedor de IA que você escolheu
-(Anthropic ou Google), autenticados pela **sua própria chave de API**.
+(Anthropic, Google ou OpenAI), autenticados pela **sua própria chave de API**.
 
 ## 1. Dados tratados e finalidade
 
 | Dado | Finalidade | Para onde vai |
 |---|---|---|
-| **Peças processuais que você marcar** (PDFs/HTML dos autos) e **suas mensagens de chat** | Análise por IA — é o propósito único da extensão | Diretamente à API do provedor escolhido por você: **Anthropic** (`api.anthropic.com`) ou **Google** (`generativelanguage.googleapis.com`). Nenhum outro serviço intermedia. |
-| **Chaves de API** (Anthropic e/ou Google) fornecidas por você | Autenticar as chamadas à API do respectivo provedor | Armazenadas **somente** no `chrome.storage.local` do seu navegador (não sincronizam entre dispositivos). Enviadas exclusivamente ao provedor correspondente, como cabeçalho de autenticação. Nunca chegam ao contexto da página do PJe. |
+| **Peças processuais que você marcar** (PDFs/HTML dos autos) e **suas mensagens de chat** | Análise por IA — é o propósito único da extensão | Diretamente à API do provedor escolhido por você: **Anthropic** (`api.anthropic.com`), **Google** (`generativelanguage.googleapis.com`) ou **OpenAI** (`api.openai.com`). Nenhum outro serviço intermedia. |
+| **Chaves de API** (Anthropic, Google e/ou OpenAI) fornecidas por você | Autenticar as chamadas à API do respectivo provedor | Armazenadas **somente** no `chrome.storage.local` do seu navegador (não sincronizam entre dispositivos). Enviadas exclusivamente ao provedor correspondente, como cabeçalho de autenticação. Nunca chegam ao contexto da página do PJe. |
 | **Preferências** (modelo, nível de raciocínio, instruções personalizadas, modo de layout) | Funcionamento da interface | Somente `chrome.storage.local`. As instruções personalizadas são anexadas ao prompt enviado ao provedor escolhido. |
 | **Prompts salvos** (título e texto que você escreve na biblioteca de prompts) | Reaproveitar instruções suas nas conversas | `chrome.storage.sync`: ficam no seu navegador e, se você usar o Chrome com uma conta Google e a sincronização ligada, o próprio Chrome os replica nos seus outros dispositivos (o desenvolvedor não tem acesso). O texto do prompt vai ao provedor de IA junto da mensagem quando você o usa. |
 | **Rascunhos de minuta** (o texto que o modelo gera ao usar “Minutar” ou “Abrir no editor”, com o que você editar) | Permitir reabrir e continuar a minuta depois, inclusive noutro dia | `chrome.storage.local` — **ficam gravados neste computador**, não sincronizam e não saem dele. São apagados automaticamente após 7 dias (mantidos no máximo os 10 mais recentes); o botão **Descartar**, no editor, remove um rascunho na hora. |
@@ -58,6 +58,11 @@ modelo que **você** escolheu e configurou:
   para melhorar produtos; no nível **pago**, não. Recomendamos usar chave de conta com
   faturamento ativo para dados sensíveis. Arquivos enviados à File API do Google expiram
   automaticamente em 48 horas.
+- **OpenAI (modelos GPT)** — [política de privacidade](https://openai.com/policies/privacy-policy)
+  e [termos de uso da API](https://openai.com/policies/row-terms-of-use). Pela política
+  vigente, a OpenAI não treina modelos com os dados enviados pela API por padrão. Arquivos
+  enviados à Files API permanecem na **sua** conta OpenAI (você pode excluí-los pelo painel
+  ou pela API).
 
 A relação contratual com o provedor de IA é **sua** (a chave de API é sua); a extensão é
 apenas o cliente técnico dessa comunicação.
@@ -92,8 +97,8 @@ de ajuda.
 - Toda comunicação usa HTTPS.
 - **Exclusão**: desinstalar a extensão apaga todos os dados locais. As chaves também
   podem ser apagadas a qualquer momento na tela de opções. Arquivos na Files API da
-  Anthropic são geridos pela sua conta Anthropic; os da File API do Google expiram em
-  48 h.
+  Anthropic e da OpenAI são geridos pela sua respectiva conta; os da File API do Google
+  expiram em 48 h.
 
 ## 6. Alterações desta política
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 **TecJustiça PJe** é uma extensão Chrome que adiciona um assistente de IA à tela de autos digitais
 do **PJe (Processo Judicial Eletrônico)**. Você marca as peças do processo, pergunta em
-linguagem natural e o modelo — **Claude (Anthropic)** ou **Gemini (Google)**, à sua
+linguagem natural e o modelo — **Claude (Anthropic)**, **Gemini (Google)** ou **GPT (OpenAI)**, à sua
 escolha — responde com base no conteúdo real dos documentos — resumos, linhas do tempo,
 partes, pedidos, provas — direto na página do processo, com a interface na paleta visual
 do próprio PJe.
@@ -59,13 +59,13 @@ investigação aberta, um agente com MCP é o caminho — o próprio painel suge
 ### Conversa e modelos
 
 - **Chat sobre os autos** — converse com o modelo sobre as peças selecionadas, com histórico multi-turno e streaming em tempo real (raciocínio do modelo em bloco colapsável).
-- **Dois provedores de IA** — modelos **Claude (Anthropic)** e **Gemini (Google)** na mesma extensão: cadastre a chave do provedor que preferir (ou as duas) e troque de modelo nas opções. Ver a tabela [Qual modelo escolher?](#-qual-modelo-escolher) abaixo.
+- **Três provedores de IA** — modelos **Claude (Anthropic)**, **Gemini (Google)** e **GPT (OpenAI)** na mesma extensão: cadastre a chave do provedor que preferir (ou as três) e troque de modelo nas opções. Ver a tabela [Qual modelo escolher?](#-qual-modelo-escolher) abaixo.
 - **Selo do modelo ativo** — a barra de ferramentas mostra o modelo e o nível de raciocínio em uso (ex.: "Gemini 3.6 Flash · raciocínio alto"), atualizado na hora ao salvar as opções; clique nele para abrir a configuração.
 - **Custo por resposta** — o rodapé estima o custo em US$ de cada resposta e o acumulado da conversa, calculado pela tabela de preços do provedor (com o desconto de cache).
 - **Citações com página** *(modelos Claude)* — as afirmações vêm com marcadores `[n]` e a lista de fontes ("Contestação, fl. 12") no rodapé; nos modelos Gemini a citação vem no próprio texto ("conforme a Contestação, fl. 12").
 - **Busca de jurisprudência** 🔍 — toggle que libera pesquisa na web (fontes oficiais: STF, STJ, Planalto, LexML…), com a consulta em andamento exibida em tempo real. Nos modelos Gemini usa o Google Search.
-- **Minutar** ✍️ *(nos dois provedores)* — peça ao modelo o texto de um ato (despacho, decisão, sentença, parecer…) e ele abre num **editor de texto** próprio, em nova aba, já com a formatação forense (A4, margens 3/2 cm, Times 12, entrelinha 1,5, parágrafos justificados). Do editor você **⎘ copia formatado** para colar no editor de minutas do PJe, **⬇ baixa em `.docx`** (Word, gerado no próprio navegador) ou **🖨 imprime/salva em PDF**. Toda afirmação leva a origem `(peça · id · fl.)` e o que faltar nas peças vira `[COMPLETAR: …]`. Toda resposta longa do chat também ganha um botão **Abrir no editor**. O rascunho fica guardado no computador (7 dias) para reabrir depois.
-- **Mapa mental** 🧠 *(nos dois provedores)* — o modelo organiza as peças marcadas nos eixos da análise processual (partes, fatos, pedidos, teses, provas, audiências, decisões, prazos, situação) e a extensão abre um **mapa interativo** em nova aba (markmap): cada eixo com ícone e cor próprios, **tabelas** onde a informação é tabular, **pílulas** de folha, id da peça, data, valor e norma, e a origem (`peça · id · fl.`) em cada tópico. Nasce recolhido, com níveis de detalhe, zoom, tema escuro, impressão/PDF e download do texto em `.md`.
+- **Minutar** ✍️ *(nos três provedores)* — peça ao modelo o texto de um ato (despacho, decisão, sentença, parecer…) e ele abre num **editor de texto** próprio, em nova aba, já com a formatação forense (A4, margens 3/2 cm, Times 12, entrelinha 1,5, parágrafos justificados). Do editor você **⎘ copia formatado** para colar no editor de minutas do PJe, **⬇ baixa em `.docx`** (Word, gerado no próprio navegador) ou **🖨 imprime/salva em PDF**. Toda afirmação leva a origem `(peça · id · fl.)` e o que faltar nas peças vira `[COMPLETAR: …]`. Toda resposta longa do chat também ganha um botão **Abrir no editor**. O rascunho fica guardado no computador (7 dias) para reabrir depois.
+- **Mapa mental** 🧠 *(nos três provedores)* — o modelo organiza as peças marcadas nos eixos da análise processual (partes, fatos, pedidos, teses, provas, audiências, decisões, prazos, situação) e a extensão abre um **mapa interativo** em nova aba (markmap): cada eixo com ícone e cor próprios, **tabelas** onde a informação é tabular, **pílulas** de folha, id da peça, data, valor e norma, e a origem (`peça · id · fl.`) em cada tópico. Nasce recolhido, com níveis de detalhe, zoom, tema escuro, impressão/PDF e download do texto em `.md`.
 - **Biblioteca de prompts** ✦ — salve instruções que você repete (título + texto) e insira-as digitando **`/`** no início do campo: o prompt vira um chip elegante acima da caixa de texto e é enviado antes da sua mensagem. Gerenciamento (criar/editar/excluir) no botão **✦ Prompts**, e os prompts acompanham você em outros navegadores pela sincronização da conta Google.
 - **OCR nativo** — peças digitalizadas (imagem) são lidas pelo próprio modelo, sem OCR externo.
 
@@ -84,7 +84,7 @@ investigação aberta, um agente com MCP é o caminho — o próprio painel suge
 
 - **Medidor de contexto dinâmico** — barra mostra quanto da janela do modelo (tokens e páginas de PDF) a conversa ocupa, atualizada ao marcar/desmarcar peças **antes mesmo do envio**, com alertas em 70% e 90%. Desmarcar uma peça **libera contexto de verdade** no request seguinte.
 - **Files API + anexo incremental** — cada peça sobe uma única vez; os turnos seguintes reaproveitam o que já está na conversa.
-- **Cache automático** — os PDFs anexados são cacheados pela API (~90% mais barato nos turnos seguintes), nos dois provedores.
+- **Cache automático** — os PDFs anexados são cacheados pela API (~90% mais barato nos turnos seguintes), nos três provedores.
 - **Retry automático** — sobrecarga da API, limites momentâneos e quedas de conexão no meio do streaming são re-tentados sozinhos, sem duplicar texto na tela.
 - **PDF × HTML detectados automaticamente** — peças HTML viram texto puro (fração do custo de um PDF); a detecção confere o content-type **e** a assinatura `%PDF-` do binário.
 - **Erros amigáveis** — chave inválida, conta sem crédito, limites e sobrecarga explicados em português.
@@ -107,8 +107,11 @@ investigação aberta, um agente com MCP é o caminho — o próprio painel suge
 | **Claude Fable 5** | 1M / 600 págs. | 10 / 50 | O mais capaz — e o mais caro e lento |
 | **Gemini 3.6 Flash** | 1M / 1000 págs. | 1,50 / 7,50 | Rápido e multimodal, ótimo custo para autos grandes |
 | **Gemini 3.5 Flash-Lite** | 1M / 1000 págs. | 0,30 / 2,50 | O mais barato e veloz — triagens e resumos |
+| **GPT-5.6 Luna** | 1,05M tokens | 0,20 / 1,20 | O GPT rápido e econômico; citações no texto |
+| **GPT-5.6 Terra** | 1,05M tokens | 2 / 12 | GPT equilibrado entre custo e capacidade; citações no texto |
+| **GPT-5.6 (Sol)** | 1,05M tokens | 5 / 30 | O GPT mais capaz; citações no texto |
 
-> Nos modelos Gemini, as citações de página vêm no próprio texto (sem os marcadores `[n]` clicáveis) — essa é a única diferença; minutar e o mapa mental funcionam igual nos dois provedores. Trocar entre Claude e Gemini no meio de uma conversa pede "Nova conversa".
+> Nos modelos Gemini e GPT, as citações de página vêm no próprio texto (sem os marcadores `[n]` clicáveis) — essa é a única diferença; minutar e o mapa mental funcionam igual nos três provedores. Trocar de provedor (Claude, Gemini ou GPT) no meio de uma conversa pede "Nova conversa".
 
 ## 🚀 Instalação
 
@@ -181,7 +184,7 @@ ids de peça, datas, valores e artigos ganham **destaque colorido**.
 quantos tópicos vieram com peça e folha. Ainda dá para alternar o **tema escuro**,
 baixar o texto em **`.md`** e **imprimir** (ou salvar em PDF, já enquadrado).
 
-> O mapa mental funciona **nos dois provedores** — Claude e Gemini —, porque é um
+> O mapa mental funciona **nos três provedores** — Claude, Gemini e GPT —, porque é um
 > chat comum, sem execução de código. Os mapas ficam disponíveis enquanto o
 > navegador estiver aberto.
 
@@ -211,7 +214,7 @@ No editor você revisa, ajusta e então:
 o modelo deixa `[COMPLETAR: …]` para quem assina preencher — nada de número, data ou
 precedente inventado. O rascunho fica **guardado no computador por 7 dias** para você
 reabrir e continuar; **Descartar**, no editor, apaga na hora. Como o mapa, minutar é um
-chat comum: funciona **em qualquer modelo**, Claude ou Gemini.
+chat comum: funciona **em qualquer modelo**, Claude, Gemini ou GPT.
 
 > A minuta é uma sugestão de trabalho, não um ato: revise o texto e confira as citações
 > nos autos antes de usar.
@@ -262,7 +265,7 @@ flowchart LR
 | `src/panel.js` / `panel.css` | UI do chat em Shadow DOM (isolada do CSS do PJe): seletor de peças, menção `@`, prompts salvos `/`, chips de contexto, card de progresso e renderizador markdown próprio e seguro. |
 | `src/prompts.js` | Biblioteca de prompts do usuário: CRUD no `chrome.storage.sync` (um item por prompt), sincronizado entre os navegadores da mesma conta Google. |
 | `src/content.js` | Orquestra: downloads paralelos, cache por peça, prompt caching, conversa multi-turno. |
-| `src/background.js` + `claude.js` / `gemini.js` | Service worker que guarda as chaves e chama a API do provedor do modelo escolhido (Anthropic ou Google) com streaming. **As chaves nunca são expostas à página.** |
+| `src/background.js` + `claude.js` / `gemini.js` / `openai.js` | Service worker que guarda as chaves e chama a API do provedor do modelo escolhido (Anthropic, Google ou OpenAI) com streaming. **As chaves nunca são expostas à página.** |
 | `src/mapa.html` + `mapa.js` / `mapa.css` | Página do **mapa mental**: converte o Markdown da resposta em árvore de nós (com ícones por eixo, tabelas e realces de fl./id) e desenha com markmap (d3), em aba própria da extensão. |
 | `vendor/` | `d3.min.js` e `markmap-view.js` oficiais, sem modificação, usados **só** pela página do mapa (nunca carregados nas páginas do PJe). Licenças em `vendor/LICENSES.md`. |
 | `src/popup.html` | Configuração em 1 clique no ícone da barra (chave, modelo, guia de primeiros passos). |
@@ -270,7 +273,7 @@ flowchart LR
 ## 🔒 Privacidade e segurança
 
 - As chaves de API ficam **somente** no `chrome.storage.local` do seu navegador (não sincronizam, não passam por servidores de terceiros).
-- Os documentos marcados são enviados **diretamente à API do provedor do modelo escolhido** (Anthropic ou Google) — nenhum outro serviço intermedia.
+- Os documentos marcados são enviados **diretamente à API do provedor do modelo escolhido** (Anthropic, Google ou OpenAI) — nenhum outro serviço intermedia.
 - A extensão só roda em sites da Justiça (`*.jus.br`), só injeta o painel em telas de autos do PJe e não coleta telemetria.
 - Política completa em [PRIVACY.md](PRIVACY.md) — sem servidor próprio, sem analytics, o desenvolvedor nunca tem acesso a nenhum dado.
 
@@ -286,8 +289,9 @@ flowchart LR
 - [x] Suporte a outros tribunais que usam PJe (TJs/TRFs/TRTs) — automático em qualquer `*.jus.br`
 - [x] Carregamento automático da timeline completa (peças fora da rolagem)
 - [x] Segundo provedor de IA — Google Gemini (3.6 Flash / 3.5 Flash-Lite)
+- [x] Terceiro provedor de IA — OpenAI GPT-5.6 (Luna / Terra / Sol)
 - [x] Preview de peças, modo lateral e "ver na timeline"
-- [x] Mapa mental interativo das peças (markmap), nos dois provedores
+- [x] Mapa mental interativo das peças (markmap), nos três provedores
 - [x] Biblioteca de prompts do usuário (`/` no campo, sincronizada entre navegadores)
 - [ ] Compaction para conversas muito longas
 - [ ] Limpeza de uploads antigos na Files API
@@ -403,4 +407,4 @@ em qual tribunal, e cole a mensagem de erro do painel (o Console do F12 também 
 
 ---
 
-<p align="center"><sub>Feito com ⚖️ para quem lê autos o dia inteiro. Não afiliado ao CNJ, à Anthropic nem ao Google.</sub></p>
+<p align="center"><sub>Feito com ⚖️ para quem lê autos o dia inteiro. Não afiliado ao CNJ, à Anthropic, ao Google nem à OpenAI.</sub></p>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "TecJustiça PJe — Análise de Processos",
   "version": "0.14.0",
-  "description": "Chat com IA (Claude ou Gemini) sobre os autos do PJe de qualquer tribunal: selecione peças e converse. Por TecJustiça.",
+  "description": "Chat com IA (Claude, Gemini ou GPT) sobre os autos do PJe de qualquer tribunal: selecione peças e converse. Por TecJustiça.",
   "permissions": ["storage", "clipboardWrite"],
   "host_permissions": [
     "https://*.jus.br/*",

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
   "host_permissions": [
     "https://*.jus.br/*",
     "https://api.anthropic.com/*",
-    "https://generativelanguage.googleapis.com/*"
+    "https://generativelanguage.googleapis.com/*",
+    "https://api.openai.com/*"
   ],
   "icons": {
     "16": "icons/icon16.png",

--- a/src/background.js
+++ b/src/background.js
@@ -3,9 +3,10 @@
 // Também resolve sozinho as continuações de turno (stop_reason "pause_turn",
 // quando o loop de ferramentas do servidor atinge o teto de iterações) — o
 // content script enxerga um único turno lógico.
-// Dois provedores: Anthropic (claude.js) e Google Gemini (gemini.js). O
-// provedor é inferido do id do modelo (prefixo "gemini-") e os dois clientes
-// emitem o MESMO vocabulário de eventos — o resto deste arquivo não distingue.
+// Três provedores: Anthropic (claude.js), Google Gemini (gemini.js) e OpenAI
+// (openai.js). O provedor é inferido do id do modelo (prefixos "gemini-" e
+// "gpt-") e os três clientes emitem o MESMO vocabulário de eventos — o resto
+// deste arquivo não distingue.
 import {
   streamClaude,
   uploadFile,
@@ -17,6 +18,11 @@ import {
   uploadFileGemini,
   countTokensGemini,
 } from "./gemini.js";
+import {
+  streamOpenAI,
+  uploadFileOpenAI,
+  countTokensOpenAI,
+} from "./openai.js";
 
 // Capacidades por modelo. Governam limites de páginas/contexto, as versões das
 // ferramentas web, a configuração de thinking/effort aceita por cada um e o
@@ -93,18 +99,69 @@ const MODEL_CAPS = {
     tokensPagina: 258,
     preco: { in: 0.3, out: 2.5, cacheRead: 0.03 },
   },
+  // Modelos OpenAI GPT-5.6 (Responses API). Família de três níveis: Sol
+  // (topo, alias "gpt-5.6"), Terra (equilibrado) e Luna (rápido/barato). Como
+  // o Gemini, a OpenAI não tem citação estruturada por página — o system
+  // prompt pede citações TEXTUAIS ("na Contestação, id 123456, fl. 12") e a UI
+  // mostra a nota (citacoesNativas:false). O effort vira reasoning.effort. Sem
+  // limite oficial de páginas de PDF (o limite é 50 MB/request) — maxPages é
+  // uma heurística de segurança. preco: US$/1M (in/out) + cacheRead (10% do
+  // input, cache automático sem cobrança de gravação). Contexto 1.05M tokens.
+  "gpt-5.6-sol": {
+    provider: "openai",
+    contextTokens: 1050000,
+    maxPages: 500,
+    webSearch: true,
+    citacoesNativas: false,
+    thinking: null,
+    effort: true, // vira reasoning.effort
+    preco: { in: 5, out: 30, cacheRead: 0.5 },
+  },
+  "gpt-5.6-terra": {
+    provider: "openai",
+    contextTokens: 1050000,
+    maxPages: 500,
+    webSearch: true,
+    citacoesNativas: false,
+    thinking: null,
+    effort: true,
+    preco: { in: 2, out: 12, cacheRead: 0.2 },
+  },
+  "gpt-5.6-luna": {
+    provider: "openai",
+    contextTokens: 1050000,
+    maxPages: 500,
+    webSearch: true,
+    citacoesNativas: false,
+    thinking: null,
+    effort: true,
+    preco: { in: 0.2, out: 1.2, cacheRead: 0.02 },
+  },
 };
 
 // Provedor do modelo (prefixo do id — a lista de modelos vive nos <option>
 // do popup/options; ids desconhecidos caem no default Anthropic via capsDe).
 function providerDe(model) {
-  return model && model.startsWith("gemini-") ? "gemini" : "anthropic";
+  if (!model) return "anthropic";
+  if (model.startsWith("gemini-")) return "gemini";
+  if (model.startsWith("gpt-")) return "openai";
+  return "anthropic";
 }
 
 // effort salvo (high/medium/low) → thinking_level do Gemini. A escala do
 // Gemini tem os mesmos três nomes (há também "minimal", que não usamos: o
 // "low" já é a opção econômica equivalente ao effort baixo da Anthropic).
 const EFFORT_PARA_THINKING_LEVEL = { high: "high", medium: "medium", low: "low" };
+
+// effort salvo → reasoning.effort da OpenAI. A escala da OpenAI é a MAIS RICA
+// dos três provedores: none | minimal | low | medium | high | xhigh | max (e
+// ainda um eixo separado reasoning.mode standard|pro|ultra). Mapeamos os três
+// níveis da extensão para o subconjunto COMUM low/medium/high — o único aceito
+// por todos os provedores E por todas as variantes 5.6 (o suporte a xhigh/max
+// é dependente do modelo e não documentado por variante; Luna/Terra podem
+// rejeitá-los com 400). "Alto" = high. Se um dia quiser expor xhigh/max, é
+// aqui (e provavelmente só para o Sol).
+const EFFORT_PARA_OPENAI = { high: "high", medium: "medium", low: "low" };
 
 // Custo estimado (US$) de um usage acumulado, pela tabela de preços do modelo.
 // A API não devolve valor monetário — só as contagens de tokens por categoria.
@@ -131,13 +188,16 @@ function capsDe(model) {
 // (1M) no popup/opções; o MODEL_CAPS e o medidor cuidam dos limites.
 function getCfg() {
   return new Promise((resolve) =>
-    chrome.storage.local.get(["apiKey", "geminiApiKey", "model", "effort"], (v) =>
-      resolve({
-        apiKey: v.apiKey,
-        geminiApiKey: v.geminiApiKey,
-        model: v.model || "claude-haiku-4-5",
-        effort: v.effort || "high",
-      })
+    chrome.storage.local.get(
+      ["apiKey", "geminiApiKey", "openaiApiKey", "model", "effort"],
+      (v) =>
+        resolve({
+          apiKey: v.apiKey,
+          geminiApiKey: v.geminiApiKey,
+          openaiApiKey: v.openaiApiKey,
+          model: v.model || "claude-haiku-4-5",
+          effort: v.effort || "high",
+        })
     )
   );
 }
@@ -151,6 +211,14 @@ function chaveDe(cfg, provider) {
       );
     }
     return cfg.geminiApiKey;
+  }
+  if (provider === "openai") {
+    if (!cfg.openaiApiKey) {
+      throw new Error(
+        "configure sua chave da API da OpenAI nas opções da extensão (o modelo escolhido é GPT)"
+      );
+    }
+    return cfg.openaiApiKey;
   }
   if (!cfg.apiKey) {
     throw new Error("configure sua ANTHROPIC_API_KEY nas opções da extensão");
@@ -214,6 +282,24 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           if (key) await sessSet(key, { uri: r.fileUri, exp: r.expiraEm });
           return sendResponse({ fileId: r.fileUri, provider });
         }
+        if (provider === "openai") {
+          // namespace próprio ("ofile:"): um file_id da OpenAI nunca pode ser
+          // lido num request Anthropic/Gemini (e vice-versa). Os arquivos da
+          // OpenAI persistem na conta, então não há validação de expiração.
+          const key = msg.payload.cacheKey ? "ofile:" + msg.payload.cacheKey : null;
+          if (key) {
+            const cached = await sessGet(key);
+            if (cached) return sendResponse({ fileId: cached, provider });
+          }
+          const fileId = await uploadFileOpenAI({
+            apiKey,
+            filename: msg.payload.filename,
+            b64: msg.payload.b64,
+            mime: msg.payload.mime,
+          });
+          if (key) await sessSet(key, fileId);
+          return sendResponse({ fileId, provider });
+        }
         const key = msg.payload.cacheKey ? "file:" + msg.payload.cacheKey : null;
         if (key) {
           const cached = await sessGet(key);
@@ -240,22 +326,32 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         const cfg = await getCfg();
         const provider = providerDe(cfg.model);
         const apiKey = chaveDe(cfg, provider);
-        const tokens =
-          provider === "gemini"
-            ? await countTokensGemini({
-                apiKey,
-                model: cfg.model,
-                system: msg.payload.system,
-                messages: msg.payload.messages,
-              })
-            : await countTokens({
-                apiKey,
-                model: cfg.model,
-                system: msg.payload.system,
-                messages: msg.payload.messages,
-                tools: msg.payload.tools,
-                betas: msg.payload.betas,
-              });
+        let tokens;
+        if (provider === "gemini") {
+          tokens = await countTokensGemini({
+            apiKey,
+            model: cfg.model,
+            system: msg.payload.system,
+            messages: msg.payload.messages,
+          });
+        } else if (provider === "openai") {
+          tokens = await countTokensOpenAI({
+            apiKey,
+            model: cfg.model,
+            system: msg.payload.system,
+            messages: msg.payload.messages,
+            tools: msg.payload.tools,
+          });
+        } else {
+          tokens = await countTokens({
+            apiKey,
+            model: cfg.model,
+            system: msg.payload.system,
+            messages: msg.payload.messages,
+            tools: msg.payload.tools,
+            betas: msg.payload.betas,
+          });
+        }
         sendResponse({ tokens, contextTokens: capsDe(cfg.model).contextTokens });
       } catch (e) {
         sendResponse({ error: String((e && e.message) || e) });
@@ -344,10 +440,16 @@ async function executarTurno(port, payload) {
   const caps = capsDe(model);
   const provider = caps.provider || "anthropic";
   const apiKey = chaveDe(cfg, provider);
-  // Os dois clientes emitem o mesmo vocabulário de eventos — daqui em diante
-  // o turno não distingue provedor (o Gemini nunca emite pause_turn, então o
-  // loop de continuações sai naturalmente na primeira iteração).
-  const streamFn = provider === "gemini" ? streamGemini : streamClaude;
+  // Os três clientes emitem o mesmo vocabulário de eventos — daqui em diante
+  // o turno não distingue provedor (nem o Gemini nem a OpenAI emitem
+  // pause_turn, então o loop de continuações sai naturalmente na primeira
+  // iteração para eles).
+  const streamFn =
+    provider === "gemini"
+      ? streamGemini
+      : provider === "openai"
+        ? streamOpenAI
+        : streamClaude;
 
   const baseReq = {
     apiKey,
@@ -360,6 +462,11 @@ async function executarTurno(port, payload) {
     // Gemini: sem betas/thinking/output_config; o effort vira thinking_level.
     if (caps.effort) {
       baseReq.thinkingLevel = EFFORT_PARA_THINKING_LEVEL[effort] || "medium";
+    }
+  } else if (provider === "openai") {
+    // OpenAI: sem betas/thinking/output_config; o effort vira reasoning.effort.
+    if (caps.effort) {
+      baseReq.effort = EFFORT_PARA_OPENAI[effort] || "medium";
     }
   } else {
     if (payload.betas && payload.betas.length) baseReq.betas = payload.betas;

--- a/src/content.js
+++ b/src/content.js
@@ -114,6 +114,9 @@
   // normal as peças são referenciadas por file_id/uri e o teto não se aplica.
   const MAX_TOTAL_B64_CHARS = 24 * 1024 * 1024;
   const MAX_TOTAL_B64_CHARS_GEMINI = 15 * 1024 * 1024;
+  // OpenAI aceita 50 MB (arquivo e somados por request); 40 MB de base64 (~30 MB
+  // decodificados) fica com folga confortável sob o limite.
+  const MAX_TOTAL_B64_CHARS_OPENAI = 40 * 1024 * 1024;
 
   // Betas enviadas em todos os requests de chat (documentos por file_id).
   const BETAS_CHAT = ["files-api-2025-04-14"];
@@ -146,6 +149,10 @@
   function toolsBusca() {
     if (!modelCaps) return [];
     if (modelCaps.provider === "gemini") return [{ type: "google_search" }];
+    // OpenAI: web_search embutida da Responses API. Não declara allowed_domains
+    // (a priorização de fontes .jus.br vai por instrução no system prompt, como
+    // no Gemini — SYSTEM_PROMPT_CIT_TEXTUAL).
+    if (modelCaps.provider === "openai") return [{ type: "web_search" }];
     return [
       {
         type: modelCaps.webSearch,
@@ -177,7 +184,11 @@
       conversaUsd: custoConversaUsd,
       usage: fim.usage,
       provedorNome:
-        modelCaps && modelCaps.provider === "gemini" ? "Google" : "Anthropic",
+        modelCaps && modelCaps.provider === "gemini"
+          ? "Google"
+          : modelCaps && modelCaps.provider === "openai"
+            ? "OpenAI"
+            : "Anthropic",
     });
   }
   // Peças cujos blocos document JÁ estão no histórico desta conversa. Anexamos
@@ -190,9 +201,10 @@
   // (mesmo com o toggle desligado) — remover trocaria o conjunto de tools,
   // invalidando o cache de prefixo e arriscando rejeição do histórico.
   let buscaNaConversa = false;
-  // Provedor (anthropic|gemini) do PRIMEIRO turno da conversa: o histórico de
-  // um provedor não é traduzível para o outro (thinking assinado da Anthropic
-  // vs. thought signatures do Gemini) — trocar no meio exige "Nova conversa".
+  // Provedor (anthropic|gemini|openai) do PRIMEIRO turno da conversa: o
+  // histórico de um provedor não é traduzível para o outro (thinking assinado
+  // da Anthropic vs. thought signatures do Gemini vs. reasoning criptografado
+  // da OpenAI) — trocar no meio exige "Nova conversa".
   let conversaProvider = null;
   let alertaTrocaLigado = false; // o alerta atual é o de troca de provedor
   let busy = false;
@@ -210,9 +222,9 @@
     "Novas mensagens não serão aceitas — desmarque peças na lista para liberar espaço " +
     "(elas saem do contexto na hora) ou comece uma nova conversa.";
   const ALERTA_TROCA_PROVEDOR =
-    "Você trocou entre um modelo Claude e um Gemini no meio da conversa — o histórico de um " +
-    "não é compatível com o outro (raciocínio assinado pelo provedor). Clique em ⟲ Nova " +
-    "conversa para usar o novo modelo, ou volte ao modelo anterior nas opções.";
+    "Você trocou de provedor de IA no meio da conversa (entre Claude, Gemini e OpenAI) — o " +
+    "histórico de um não é compatível com o outro (raciocínio assinado pelo provedor). Clique " +
+    "em ⟲ Nova conversa para usar o novo modelo, ou volte ao modelo anterior nas opções.";
 
   const panel = PjePanel.mount();
 
@@ -340,23 +352,35 @@
   function refreshKey() {
     if (!extensaoViva()) return;
     try {
-      // a chave exigida é a do PROVEDOR do modelo escolhido (Anthropic ou
-      // Google) — o provedor sai do prefixo do id, sem esperar o caps chegar.
-      // customPrompt pega carona na mesma leitura (evita um get a mais).
-      chrome.storage.local.get(["apiKey", "geminiApiKey", "model", "customPrompt"], (v) => {
-        customPrompt = (v.customPrompt || "").trim();
-        const gemini = String(v.model || "").startsWith("gemini-");
-        panel.setConfigured(gemini ? !!v.geminiApiKey : !!v.apiKey);
-      });
+      // a chave exigida é a do PROVEDOR do modelo escolhido (Anthropic, Google
+      // ou OpenAI) — o provedor sai do prefixo do id, sem esperar o caps
+      // chegar. customPrompt pega carona na mesma leitura (evita um get a mais).
+      chrome.storage.local.get(
+        ["apiKey", "geminiApiKey", "openaiApiKey", "model", "customPrompt"],
+        (v) => {
+          customPrompt = (v.customPrompt || "").trim();
+          const m = String(v.model || "");
+          const configurado = m.startsWith("gemini-")
+            ? !!v.geminiApiKey
+            : m.startsWith("gpt-")
+              ? !!v.openaiApiKey
+              : !!v.apiKey;
+          panel.setConfigured(configurado);
+        }
+      );
     } catch {
       avisarContextoPerdido();
     }
   }
   refreshKey();
   chrome.storage.onChanged.addListener((ch, area) => {
-    if (area === "local" && (ch.apiKey || ch.geminiApiKey || ch.model)) refreshKey();
+    if (area === "local" && (ch.apiKey || ch.geminiApiKey || ch.openaiApiKey || ch.model))
+      refreshKey();
     // effort entra aqui por causa do selo do modelo (mostra o nível ativo)
-    if (area === "local" && (ch.model || ch.apiKey || ch.geminiApiKey || ch.effort))
+    if (
+      area === "local" &&
+      (ch.model || ch.apiKey || ch.geminiApiKey || ch.openaiApiKey || ch.effort)
+    )
       refreshCaps();
     if (area === "local" && ch.customPrompt) {
       customPrompt = String(ch.customPrompt.newValue || "").trim();
@@ -683,17 +707,22 @@
       }
     }
     const tetoB64 =
-      provAtual === "gemini" ? MAX_TOTAL_B64_CHARS_GEMINI : MAX_TOTAL_B64_CHARS;
+      provAtual === "gemini"
+        ? MAX_TOTAL_B64_CHARS_GEMINI
+        : provAtual === "openai"
+          ? MAX_TOTAL_B64_CHARS_OPENAI
+          : MAX_TOTAL_B64_CHARS;
     if (totalB64 > tetoB64) {
       const mb = Math.round(totalB64 / 1024 / 1024);
       throw new Error(
         `as peças selecionadas somam ~${mb} MB — acima do limite da análise. Desmarque algumas peças maiores e tente de novo.`
       );
     }
-    // Breakpoint de cache é conceito da Anthropic; o Gemini usa implicit
-    // caching (automático) e o gemini.js nem copiaria o campo — mas não
-    // sujar o histórico evita surpresas se o usuário voltar ao Claude.
-    if (blocks.length && provAtual !== "gemini") {
+    // Breakpoint de cache é conceito EXCLUSIVO da Anthropic; Gemini e OpenAI
+    // usam cache automático (implicit) e os clientes deles nem copiariam o
+    // campo — mas não sujar o histórico evita surpresas se o usuário voltar ao
+    // Claude.
+    if (blocks.length && provAtual === "anthropic") {
       blocks[blocks.length - 1].cache_control = { type: "ephemeral" };
     }
     return blocks;

--- a/src/help.html
+++ b/src/help.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
   <head>
     <meta charset="utf-8" />
-    <title>TecJustiça PJe — Como criar sua chave da API (Anthropic ou Google)</title>
+    <title>TecJustiça PJe — Como criar sua chave da API (Anthropic, Google ou OpenAI)</title>
     <link rel="stylesheet" href="ui.css" />
     <style>
       body { display: block; padding: 0 0 60px; }
@@ -82,10 +82,11 @@
     <div class="page">
       <h1 class="serif">Criar sua chave da API da Anthropic</h1>
       <p class="lead">
-        A extensão funciona com os modelos <strong>Claude (Anthropic)</strong> e
-        <strong>Gemini (Google)</strong> — basta ter a chave do provedor do modelo escolhido.
-        Esta seção cobre a Anthropic; a chave do Google está
-        <a class="link" href="#gemini">logo abaixo</a>. Você precisa de uma
+        A extensão funciona com os modelos <strong>Claude (Anthropic)</strong>,
+        <strong>Gemini (Google)</strong> e <strong>GPT (OpenAI)</strong> — basta ter a chave do
+        provedor do modelo escolhido. Esta seção cobre a Anthropic; a chave do Google está
+        <a class="link" href="#gemini">mais abaixo</a> e a da OpenAI
+        <a class="link" href="#openai">na sequência</a>. Você precisa de uma
         <strong>chave de API própria</strong> e de <strong>crédito</strong> na sua conta. Leva ~3 minutos.
       </p>
 
@@ -174,6 +175,38 @@
         inclusive gerar minutas e o mapa mental — funciona igual.</em></p>
       </div>
 
+      <h1 class="serif" id="openai">Criar sua chave da API da OpenAI (GPT)</h1>
+      <p class="lead">
+        Para usar os modelos <strong>GPT-5.6</strong> (Luna, Terra e Sol), crie uma chave na
+        plataforma de desenvolvedores da OpenAI. Leva ~3 minutos e exige crédito na conta.
+      </p>
+
+      <div class="card">
+        <div class="head"><div class="num">1</div><h2>Acesse a plataforma da OpenAI</h2></div>
+        <p>Crie uma conta (ou entre) no painel de desenvolvedores — é diferente do ChatGPT.</p>
+        <a class="gobtn" href="https://platform.openai.com/api-keys" target="_blank" rel="noopener">Abrir platform.openai.com ↗</a>
+      </div>
+
+      <div class="card">
+        <div class="head"><div class="num">2</div><h2>Adicione crédito</h2></div>
+        <p>Vá em <strong>Settings → Billing</strong> e adicione crédito pré-pago. Um valor pequeno
+        já basta para começar — a OpenAI cobra por uso.</p>
+        <a class="gobtn" href="https://platform.openai.com/settings/organization/billing" target="_blank" rel="noopener">Abrir Billing ↗</a>
+      </div>
+
+      <div class="card">
+        <div class="head"><div class="num">3</div><h2>Crie a API Key e cole na extensão</h2></div>
+        <p>Em <strong>API keys → Create new secret key</strong>, gere a chave (começa com
+        <code>sk-...</code>) e copie na hora — ela aparece uma única vez.</p>
+        <ul>
+          <li>Clique no ícone <strong>⚖️ TecJustiça PJe</strong> na barra do Chrome.</li>
+          <li>Cole a chave no campo <strong>"Chave da API — OpenAI (GPT)"</strong>, escolha um modelo GPT e clique em <strong>Salvar</strong>.</li>
+        </ul>
+        <p style="margin-top:10px"><em>Como no Gemini, as citações de página aparecem no próprio
+        texto da resposta (sem os marcadores [n] clicáveis). Todo o resto — inclusive minutas e o
+        mapa mental — funciona igual.</em></p>
+      </div>
+
       <h1 class="serif" id="modelos">Qual modelo escolher?</h1>
       <div class="card">
         <p>O selo na barra de ferramentas do chat mostra sempre o modelo e o nível de
@@ -188,10 +221,14 @@
           <tr><td><strong>Claude Fable 5</strong></td><td>1M tokens / 600 págs.</td><td>10 / 50</td><td>O mais capaz — e o mais caro e lento. Para casos excepcionais.</td></tr>
           <tr><td><strong>Gemini 3.6 Flash</strong></td><td>1M tokens / 1000 págs.</td><td>1,50 / 7,50</td><td>Rápido, multimodal e com ótimo custo para autos grandes. Citações no texto.</td></tr>
           <tr><td><strong>Gemini 3.5 Flash-Lite</strong></td><td>1M tokens / 1000 págs.</td><td>0,30 / 2,50</td><td>O mais barato e veloz de todos — ideal para triagens e resumos rápidos. Citações no texto.</td></tr>
+          <tr><td><strong>GPT-5.6 Luna</strong></td><td>1,05M tokens</td><td>0,20 / 1,20</td><td>O GPT rápido e econômico — bom para triagens e o dia a dia. Citações no texto.</td></tr>
+          <tr><td><strong>GPT-5.6 Terra</strong></td><td>1,05M tokens</td><td>2 / 12</td><td>GPT equilibrado entre custo e capacidade. Citações no texto.</td></tr>
+          <tr><td><strong>GPT-5.6 (Sol)</strong></td><td>1,05M tokens</td><td>5 / 30</td><td>O GPT mais capaz — para análises delicadas. Citações no texto.</td></tr>
         </table>
         <p style="margin-top:10px"><em>Regra prática: Haiku para o dia a dia; Gemini 3.5
-        Flash-Lite quando o custo importa mais; Sonnet 5 ou Gemini 3.6 Flash para autos
-        volumosos; Opus/Fable quando a qualidade da análise vale o preço.</em></p>
+        Flash-Lite ou GPT-5.6 Luna quando o custo importa mais; Sonnet 5, Gemini 3.6 Flash ou
+        GPT-5.6 Terra para autos volumosos; Opus/Fable ou GPT-5.6 (Sol) quando a qualidade da
+        análise vale o preço.</em></p>
       </div>
 
       <h1 class="serif">Como usar bem o chat (fluxo recomendado)</h1>
@@ -210,13 +247,13 @@
           copia para o PJe, baixa em Word (.docx) ou imprime; e <strong>🧠 Mapa mental</strong>
           para ver a estrutura do feito — partes, fatos, pedidos, teses, provas, decisões e
           situação atual — num mapa interativo. Minutar e o mapa funcionam em <strong>qualquer
-          modelo</strong>, Claude ou Gemini, sempre com a peça, o <em>id</em> e a folha de origem.</li>
+          modelo</strong>, Claude, Gemini ou GPT, sempre com a peça, o <em>id</em> e a folha de origem.</li>
           <li>Siga a conversa: <strong>adicionar</strong> peças no meio é barato; para
           <strong>remover</strong> várias ou mudar de assunto, prefira ⟲ Nova conversa.</li>
           <li><strong>Personalize o assistente</strong>: nas opções, o campo
           <strong>"Instruções personalizadas"</strong> diz ao modelo quem você é e como quer as
           respostas (ex.: "Sou assessor de vara criminal; destaque prazos prescricionais") —
-          vale para os modelos Claude e Gemini, no chat, nas minutas e no mapa.</li>
+          vale para os modelos Claude, Gemini e GPT, no chat, nas minutas e no mapa.</li>
         </ol>
       </div>
 
@@ -231,7 +268,7 @@
           ponto em diante (o turno seguinte re-paga o envio das peças restantes). Use quando o medidor
           encher; para trocar de assunto ou remodelar a seleção inteira, prefira <strong>⟲ Nova conversa</strong>.</li>
           <li><strong>O medidor no rodapé é o guia</strong>: perto de 90% da janela do modelo, desmarque
-          peças ou abra uma conversa nova. Vale para Claude e Gemini (ambos têm cache automático).</li>
+          peças ou abra uma conversa nova. Vale para Claude, Gemini e GPT (todos têm cache automático).</li>
         </ul>
       </div>
 
@@ -255,7 +292,7 @@
 
       <div class="warn-box">
         🔒 Suas chaves ficam só neste navegador (não são enviadas a lugar nenhum além das próprias APIs
-        da Anthropic e do Google). As peças que você marcar são enviadas ao modelo escolhido para
+        da Anthropic, do Google e da OpenAI). As peças que você marcar são enviadas ao modelo escolhido para
         análise — processos podem conter dados sigilosos, use com critério.
         <strong>As minutas geradas ficam guardadas neste computador</strong> (para você reabri-las
         depois) e são apagadas automaticamente após 7 dias — use <strong>Descartar</strong>, no

--- a/src/openai.js
+++ b/src/openai.js
@@ -1,0 +1,449 @@
+// Cliente da API da OpenAI (Responses API), irmão de claude.js e gemini.js.
+// Emite o MESMO vocabulário de eventos que streamClaude/streamGemini — o
+// background.js consome os três sem saber qual provedor está por trás:
+//   {kind:"text", text}          — delta de texto da resposta
+//   {kind:"thinking", text}      — delta do resumo de raciocínio ("" no início)
+//   {kind:"citation", citation}  — citação (annotations url_citation → formato
+//                                  web_search_result_location que a UI já trata)
+//   {kind:"tool", name, input}   — o servidor executou a busca web
+//   {kind:"trunc"}               — resposta cortada pelo teto de saída
+//   {kind:"final", content, stopReason, containerId, usage} — fim do request
+//
+// FORMATOS DA RESPONSES API (developers.openai.com, GA em 2026 — sem header
+// beta; a API antiga /v1/chat/completions NÃO é usada):
+//  - Request: POST {base}/responses, header Authorization: Bearer <key>.
+//    Body: {model, instructions, input, store:false, stream:true,
+//    reasoning:{effort, summary:"auto"}, include:["reasoning.encrypted_content"],
+//    max_output_tokens, tools?}. O system prompt vai em `instructions` (nível
+//    superior), NÃO no input. store:false = modo STATELESS (nada é guardado no
+//    servidor; o histórico inteiro é reenviado a cada request, como na
+//    Anthropic e no Gemini).
+//  - input (modo STATELESS): array de itens, na ORDEM original:
+//    * turno do usuário: {role:"user", content:[{type:"input_text",text} |
+//      {type:"input_file", file_id | (filename + file_data:"data:...;base64,")}]}
+//    * turno do modelo (histórico): os PRÓPRIOS itens de `response.output`,
+//      VERBATIM — {type:"reasoning", id, summary, encrypted_content} e
+//      {type:"message", id, role:"assistant", status:"completed",
+//      content:[{type:"output_text",text}]}. Os itens `reasoning` carregam
+//      conteúdo criptografado e DEVEM voltar intactos (regra igual à do
+//      thinking assinado da Anthropic e do thought_signature do Gemini), por
+//      isso o `include:["reasoning.encrypted_content"]` no request.
+//  - Streaming (SSE, "data: {json}"): cada evento tem um campo `type`.
+//    Eventos usados: response.output_item.added (item novo: reasoning começou,
+//    web_search_call…), response.output_text.delta {delta},
+//    response.reasoning_summary_text.delta {delta},
+//    response.output_text.annotation.added {annotation}, response.completed
+//    {response}, response.incomplete {response}, response.failed {response},
+//    error. O evento final (completed/incomplete) traz `response.output`
+//    (itens completos) e `response.usage`.
+//  - usage (response.usage): input_tokens (INCLUI cache),
+//    input_tokens_details.cached_tokens, output_tokens (INCLUI reasoning),
+//    output_tokens_details.reasoning_tokens.
+//  - Files API: POST {base}/files (multipart: file + purpose:"user_data");
+//    resposta {id}. Os arquivos persistem na conta (não expiram por padrão),
+//    então o cache de sessão não precisa validar expiração (ao contrário do
+//    Gemini). PDF: ≤ 50 MB por arquivo / ≤ 50 MB somados por request.
+//  - countTokens: POST {base}/responses/input_tokens com o MESMO corpo do
+//    /responses (model, instructions, input, tools) → {input_tokens}. É o
+//    análogo gratuito ao count_tokens da Anthropic.
+
+const API = "https://api.openai.com/v1";
+
+// Teto de saída explícito (reasoning + texto contam juntos): generoso para a
+// resposta nunca ser cortada por um default menor, e limitado para custo e
+// latência previsíveis. 65.536 é folga enorme para uma minuta jurídica somada
+// ao resumo de raciocínio (o máximo dos modelos 5.6 é 128.000).
+const MAX_OUTPUT_TOKENS = 65536;
+
+function headersOpenAI(apiKey) {
+  return {
+    "content-type": "application/json",
+    authorization: "Bearer " + apiKey,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tradução do histórico interno (blocos estilo Anthropic, o formato canônico
+// da extensão) para o input stateless da Responses API. Regras:
+//  - document file/base64 → item {type:"input_file"} precedido de um item de
+//    texto "[Peça anexada: título]" (o input_file por file_id não tem `title`,
+//    e o system prompt exige citar as peças pelo nome);
+//  - document text (peças HTML) → item de texto com o título como cabeçalho;
+//  - blocos do assistant: {type:"text"} viram um item {type:"message",
+//    role:"assistant"}; {type:"x-openai-item", raw} é o item ORIGINAL da
+//    resposta (reasoning criptografado, chamadas de busca) e volta VERBATIM.
+// Campos internos/proprietários (cache_control, citations, __pecaId) nunca são
+// copiados: os itens de usuário são construídos do zero.
+// ---------------------------------------------------------------------------
+function traduzirHistorico(messages) {
+  const input = [];
+  for (const turn of messages || []) {
+    if (turn.role === "user") {
+      const content = [];
+      const blocos =
+        typeof turn.content === "string"
+          ? [{ type: "text", text: turn.content }]
+          : turn.content || [];
+      for (const b of blocos) {
+        if (!b) continue;
+        if (b.type === "document") {
+          const t = b.title || "peça do processo";
+          const src = b.source || {};
+          if (src.type === "file") {
+            content.push({ type: "input_text", text: "[Peça anexada: " + t + "]" });
+            content.push({ type: "input_file", file_id: src.file_id });
+          } else if (src.type === "base64") {
+            content.push({ type: "input_text", text: "[Peça anexada: " + t + "]" });
+            content.push({
+              type: "input_file",
+              filename: "peca.pdf",
+              file_data:
+                "data:" + (src.media_type || "application/pdf") + ";base64," + src.data,
+            });
+          } else if (src.type === "text") {
+            content.push({
+              type: "input_text",
+              text: "=== Peça: " + t + " ===\n" + (src.data || ""),
+            });
+          }
+        } else if (b.type === "text") {
+          content.push({ type: "input_text", text: b.text || "" });
+        }
+        // outros tipos em turno de usuário não existem no fluxo da extensão
+      }
+      if (content.length) input.push({ role: "user", content });
+    } else {
+      // turno do assistant: itens opacos (reasoning, busca) entram VERBATIM, na
+      // ordem em que vieram; textos viram um item message reconstruído. A ordem
+      // [reasoning, message] é preservada — a API exige que um item reasoning
+      // seja seguido pelo item que ele produziu.
+      let textos = [];
+      const flush = () => {
+        if (textos.length) {
+          input.push({
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: textos,
+          });
+          textos = [];
+        }
+      };
+      const blocos =
+        typeof turn.content === "string"
+          ? [{ type: "text", text: turn.content }]
+          : turn.content || [];
+      for (const b of blocos) {
+        if (!b) continue;
+        if (b.type === "x-openai-item" && b.raw) {
+          flush();
+          input.push(b.raw);
+        } else if (b.type === "text") {
+          textos.push({ type: "output_text", text: b.text || "" });
+        }
+        // blocos de outro provedor não chegam aqui: trocar de provedor no meio
+        // da conversa é bloqueado na UI
+      }
+      flush();
+    }
+  }
+  return input;
+}
+
+// req: {apiKey, model, system, messages, tools?, effort?}
+// Campos do caminho Anthropic (betas, container, thinking, output_config,
+// max_tokens) são simplesmente ignorados — em especial max_tokens (32000):
+// aqui o teto é MAX_OUTPUT_TOKENS (ver o cabeçalho do arquivo).
+export async function* streamOpenAI(req) {
+  const body = {
+    model: req.model,
+    instructions: req.system,
+    input: traduzirHistorico(req.messages),
+    store: false,
+    stream: true,
+    max_output_tokens: MAX_OUTPUT_TOKENS,
+    // conteúdo de raciocínio criptografado volta no histórico (stateless):
+    // precisa vir para poder ser reenviado verbatim nos turnos seguintes.
+    include: ["reasoning.encrypted_content"],
+  };
+  if (req.effort) {
+    // summary:"auto" liga o RESUMO de raciocínio no stream (o "pensando…" da
+    // UI). context:"all_turns" faz o modelo usar o raciocínio de todos os
+    // turnos reenviados.
+    body.reasoning = { effort: req.effort, summary: "auto", context: "all_turns" };
+  }
+  if (req.tools && req.tools.length) body.tools = req.tools;
+
+  const resp = await fetch(API + "/responses", {
+    method: "POST",
+    headers: headersOpenAI(req.apiKey),
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const err = new Error(await friendlyHttpErrorOpenAI(resp));
+    err.status = resp.status;
+    // transitórios: o chamador re-tenta o MESMO request com backoff
+    err.retryable = resp.status === 429 || resp.status >= 500;
+    throw err;
+  }
+
+  // A resposta final (response.completed/incomplete) traz `output` (os itens
+  // completos) e `usage` — essa é a versão oficial que guardamos no histórico.
+  let respostaFinal = null;
+  let statusFinal = null;
+
+  for await (const ev of sseEvents(resp)) {
+    const tipo = ev.type || "";
+    if (tipo === "response.output_text.delta") {
+      yield { kind: "text", text: ev.delta || "" };
+    } else if (tipo === "response.reasoning_summary_text.delta") {
+      yield { kind: "thinking", text: ev.delta || "" };
+    } else if (tipo === "response.output_item.added") {
+      const it = ev.item || {};
+      if (it.type === "reasoning") {
+        // sinaliza o início do raciocínio (mesma convenção do claude.js: um
+        // thinking "" acende o indicador "Raciocinando…" na UI)
+        yield { kind: "thinking", text: "" };
+      } else if (it.type === "web_search_call") {
+        const q =
+          (it.action && it.action.query) ||
+          (it.action && it.action.queries && it.action.queries[0]) ||
+          null;
+        yield { kind: "tool", name: "web_search", input: { query: q } };
+      }
+    } else if (tipo === "response.output_text.annotation.added") {
+      // citações da busca chegam ao vivo, no ponto do texto. Só url_citation
+      // (web) — a citação de arquivo (file_citation) não tem página e, no modo
+      // textual, o próprio modelo escreve a peça/folha no corpo do texto.
+      const a = ev.annotation || {};
+      if (a.type === "url_citation") {
+        yield {
+          kind: "citation",
+          citation: {
+            type: "web_search_result_location",
+            url: a.url,
+            title: a.title,
+          },
+        };
+      }
+    } else if (tipo === "response.completed") {
+      respostaFinal = ev.response || null;
+      statusFinal = "completed";
+    } else if (tipo === "response.incomplete") {
+      respostaFinal = ev.response || null;
+      statusFinal = "incomplete";
+    } else if (tipo === "response.failed") {
+      const e = ev.response && ev.response.error;
+      const err = new Error((e && e.message) || "a API da OpenAI encerrou o turno com falha — tente de novo");
+      err.retryable = /server_error|rate_limit|overloaded|timeout/i.test(
+        (e && (e.type || e.code)) || ""
+      );
+      throw err;
+    } else if (tipo === "error") {
+      const e = ev.error || ev;
+      const err = new Error((e && e.message) || "erro no stream da API da OpenAI");
+      err.retryable = /server_error|rate_limit|overloaded|timeout/i.test(
+        (e && (e.type || e.code)) || ""
+      );
+      throw err;
+    }
+  }
+
+  // Stream encerrado SEM o evento de conclusão: conexão caiu de forma "limpa"
+  // no meio do turno (proxy, rede) — a resposta parcial não pode passar por
+  // completa. Erro re-tentável: o executarTurno re-tenta o mesmo request (o
+  // prefixo está no cache automático da OpenAI, custa pouco).
+  if (!respostaFinal) {
+    const err = new Error(
+      "o stream da API da OpenAI terminou sem o evento de conclusão — tente de novo"
+    );
+    err.retryable = true;
+    throw err;
+  }
+
+  const output = Array.isArray(respostaFinal.output) ? respostaFinal.output : [];
+  const stopReason = mapStopReason(respostaFinal, statusFinal);
+  if (stopReason === "max_tokens") yield { kind: "trunc" };
+
+  yield {
+    kind: "final",
+    content: itensParaBlocos(output),
+    stopReason,
+    containerId: null,
+    usage: normalizarUsage(respostaFinal.usage),
+  };
+}
+
+// Converte os itens de output da OpenAI nos blocos que a extensão guarda no
+// histórico:
+//  - message do assistant só de texto (output_text) → blocos {type:"text"}
+//    comuns (compatíveis com sanearCitacoes, transcript e o fallback do
+//    content.js); as annotations ficam só na UI (regra igual à das citações da
+//    Anthropic e das annotations do Gemini);
+//  - qualquer outro item (reasoning criptografado, web_search_call, message
+//    com recusa) → {type:"x-openai-item", raw} — wrapper OPACO que
+//    prepararEnvio e sanearCitacoes não tocam; traduzirHistorico devolve o raw
+//    verbatim.
+function itensParaBlocos(output) {
+  const blocos = [];
+  for (const it of output) {
+    if (!it) continue;
+    const soTexto =
+      it.type === "message" &&
+      Array.isArray(it.content) &&
+      it.content.length > 0 &&
+      it.content.every((c) => c && c.type === "output_text");
+    if (soTexto) {
+      for (const c of it.content) blocos.push({ type: "text", text: c.text || "" });
+    } else {
+      blocos.push({ type: "x-openai-item", raw: it });
+    }
+  }
+  return blocos;
+}
+
+// status da resposta → vocabulário de stop_reason que a extensão já trata. A
+// OpenAI não tem pause_turn: o loop de continuação do background sai
+// naturalmente na primeira iteração.
+function mapStopReason(resp, statusFinal) {
+  // recusa explícita: um item message com content de tipo "refusal"
+  const output = Array.isArray(resp.output) ? resp.output : [];
+  for (const it of output) {
+    if (it && it.type === "message" && Array.isArray(it.content)) {
+      if (it.content.some((c) => c && c.type === "refusal")) return "refusal";
+    }
+  }
+  if (statusFinal === "incomplete") {
+    const motivo =
+      (resp.incomplete_details && resp.incomplete_details.reason) || "";
+    if (/content_filter|safety/i.test(motivo)) return "refusal";
+    return "max_tokens"; // max_output_tokens (o caso comum de incomplete)
+  }
+  return "end_turn";
+}
+
+// usage da OpenAI → as 4 categorias estilo Anthropic que custo/gauge/tooltip
+// já consomem. input_tokens INCLUI os cacheados; o cache automático não tem
+// "gravação" cobrada à parte (cache_creation = 0). output_tokens já inclui os
+// tokens de raciocínio.
+function normalizarUsage(u) {
+  if (!u) return null;
+  const cached = (u.input_tokens_details && u.input_tokens_details.cached_tokens) || 0;
+  const input = Math.max(0, (u.input_tokens || 0) - cached);
+  return {
+    input_tokens: input,
+    cache_read_input_tokens: cached,
+    cache_creation_input_tokens: 0,
+    output_tokens: u.output_tokens || 0,
+  };
+}
+
+// Itera os eventos SSE ("data: {...}") do corpo da resposta (mesmo parser do
+// claude.js/gemini.js — o framing SSE é idêntico; a Responses API não manda
+// [DONE], termina o stream após response.completed, mas tratamos [DONE] por
+// segurança).
+async function* sseEvents(resp) {
+  const reader = resp.body.getReader();
+  const dec = new TextDecoder();
+  let buf = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += dec.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, idx).trim();
+      buf = buf.slice(idx + 1);
+      if (!line.startsWith("data:")) continue;
+      const data = line.slice(5).trim();
+      if (data === "[DONE]") return;
+      let ev;
+      try {
+        ev = JSON.parse(data);
+      } catch {
+        continue;
+      }
+      yield ev;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Upload à Files API da OpenAI (multipart em uma etapa). Devolve o file_id. Os
+// arquivos persistem na conta (sem expiração por padrão), então o chamador
+// guarda só o id no cache de sessão — sem validação de expiração.
+// ---------------------------------------------------------------------------
+export async function uploadFileOpenAI({ apiKey, filename, b64, mime }) {
+  const mimeType = mime || "application/pdf";
+  const blob = await (await fetch("data:" + mimeType + ";base64," + b64)).blob();
+  const fd = new FormData();
+  // purpose "user_data": o valor para documentos de entrada da Responses API
+  fd.append("purpose", "user_data");
+  fd.append("file", blob, filename || "documento.pdf");
+  const resp = await fetch(API + "/files", {
+    method: "POST",
+    headers: { authorization: "Bearer " + apiKey }, // sem content-type: FormData define o boundary
+    body: fd,
+  });
+  if (!resp.ok) throw new Error(await friendlyHttpErrorOpenAI(resp));
+  const j = await resp.json();
+  if (!j || !j.id) throw new Error("a Files API da OpenAI não retornou o id do arquivo");
+  return j.id;
+}
+
+// ---------------------------------------------------------------------------
+// Contagem de tokens (endpoint dedicado /responses/input_tokens — mesmo corpo
+// do /responses). Conta exatamente entrada + arquivos/imagens + schemas das
+// tools. A guarda de 90% da janela e o usage pós-turno usam este número.
+// ---------------------------------------------------------------------------
+export async function countTokensOpenAI({ apiKey, model, system, messages, tools }) {
+  const body = {
+    model,
+    instructions: system,
+    input: traduzirHistorico(messages),
+  };
+  if (tools && tools.length) body.tools = tools;
+  const resp = await fetch(API + "/responses/input_tokens", {
+    method: "POST",
+    headers: headersOpenAI(apiKey),
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) throw new Error(await friendlyHttpErrorOpenAI(resp));
+  const j = await resp.json();
+  return (j && (j.input_tokens || j.total_tokens)) || 0;
+}
+
+// Converte respostas de erro da API da OpenAI em mensagens claras em português.
+export async function friendlyHttpErrorOpenAI(resp) {
+  let apiMsg = "";
+  try {
+    const j = await resp.json();
+    apiMsg = (j && j.error && j.error.message) || "";
+  } catch {
+    /* corpo não-JSON */
+  }
+  const low = apiMsg.toLowerCase();
+
+  if (resp.status === 401) {
+    return "Chave da API da OpenAI inválida. Confira a chave nas configurações da extensão.";
+  }
+  if (resp.status === 403) {
+    return "Chave da API da OpenAI sem permissão para este recurso ou região. Confira em platform.openai.com.";
+  }
+  if (resp.status === 429 && (low.includes("quota") || low.includes("billing") || low.includes("insufficient"))) {
+    return "Sua conta OpenAI está sem crédito ou atingiu a cota. Adicione crédito em platform.openai.com → Billing.";
+  }
+  if (resp.status === 400 && (low.includes("context") || low.includes("maximum") || low.includes("too many tokens"))) {
+    return "As peças selecionadas excedem o contexto do modelo. Desmarque algumas peças ou inicie uma nova conversa.";
+  }
+  if (resp.status === 429) {
+    return "Limite de requisições da API da OpenAI atingido. Aguarde alguns instantes e tente de novo.";
+  }
+  if (resp.status === 413 || (resp.status === 400 && low.includes("too large"))) {
+    return "As peças selecionadas são grandes demais para uma única análise. Desmarque algumas e tente novamente.";
+  }
+  if (resp.status >= 500) {
+    return "A API da OpenAI está sobrecarregada no momento. Tente novamente em instantes.";
+  }
+  return "Erro da API da OpenAI (" + resp.status + ")" + (apiMsg ? ": " + apiMsg.slice(0, 240) : "");
+}

--- a/src/options.html
+++ b/src/options.html
@@ -17,7 +17,7 @@
         <img src="../icons/icon48.png" alt="" />
         <div>
           <div class="t">TecJustiça PJe — Configuração</div>
-          <div class="s">Análise de autos com IA — Claude ou Gemini</div>
+          <div class="s">Análise de autos com IA — Claude, Gemini ou GPT</div>
         </div>
       </div>
 
@@ -46,6 +46,16 @@
           <button class="toggle-pw" id="togglePwG" type="button">mostrar</button>
         </div>
 
+        <label class="field" for="openaiApiKey">
+          Chave da API — OpenAI (modelos GPT)
+          <span class="kstate" id="kstateO">não configurada</span>
+          <span class="hint">Opcional. Crie em platform.openai.com — <a href="help.html#openai" target="_blank" style="color:var(--pje-2);font-weight:600">passo a passo →</a></span>
+        </label>
+        <div class="pw-row">
+          <input id="openaiApiKey" type="password" placeholder="sk-..." autocomplete="off" />
+          <button class="toggle-pw" id="togglePwO" type="button">mostrar</button>
+        </div>
+
         <label class="field" for="model">Modelo</label>
         <select id="model">
           <optgroup label="Claude (Anthropic)">
@@ -58,6 +68,11 @@
             <option value="gemini-3.6-flash">Gemini 3.6 Flash (1M tokens, até 1000 págs. — rápido)</option>
             <option value="gemini-3.5-flash-lite">Gemini 3.5 Flash-Lite (1M tokens — o mais barato)</option>
           </optgroup>
+          <optgroup label="GPT (OpenAI)">
+            <option value="gpt-5.6-luna">GPT-5.6 Luna (1M tokens — rápido e barato)</option>
+            <option value="gpt-5.6-terra">GPT-5.6 Terra (1M tokens — equilibrado)</option>
+            <option value="gpt-5.6-sol">GPT-5.6 (Sol — o mais capaz)</option>
+          </optgroup>
         </select>
 
         <label class="field" for="effort">Nível de raciocínio</label>
@@ -67,11 +82,11 @@
             <option value="medium">Médio</option>
             <option value="low">Baixo</option>
           </select>
-          <span class="side-hint">Alto = mais qualidade; baixo = mais rápido e barato. Nos modelos Gemini vira o nível de <i>thinking</i>.</span>
+          <span class="side-hint">Alto = mais qualidade; baixo = mais rápido e barato. Nos modelos Gemini vira o nível de <i>thinking</i>; nos GPT, o <i>reasoning effort</i>.</span>
         </div>
 
         <label class="field" for="customPrompt">Instruções personalizadas (opcional)
-          <span class="hint">Diga quem você é e como quer as respostas — vale para os modelos Claude e Gemini, no chat e no .docx. Ex.: "Sou assessor de gabinete de vara criminal; destaque prazos prescricionais e regime de pena." Alterar isso no meio de uma conversa invalida o cache (o turno seguinte custa um pouco mais).</span>
+          <span class="hint">Diga quem você é e como quer as respostas — vale para os modelos Claude, Gemini e GPT, no chat e no .docx. Ex.: "Sou assessor de gabinete de vara criminal; destaque prazos prescricionais e regime de pena." Alterar isso no meio de uma conversa invalida o cache (o turno seguinte custa um pouco mais).</span>
         </label>
         <textarea id="customPrompt" rows="4" maxlength="4000" placeholder="Ex.: Sou advogado(a) da parte autora; aponte riscos e teses favoráveis…"></textarea>
 
@@ -79,7 +94,7 @@
         <div class="save-status" id="saveStatus"></div>
 
         <div class="note">
-          ⚠️ As peças selecionadas são enviadas à API do provedor do modelo escolhido (Anthropic ou Google). Processos podem conter dados pessoais/sigilosos — use conforme as normas do seu tribunal. <a href="https://github.com/marcosmarf27/pje-ia/blob/main/PRIVACY.md" target="_blank" rel="noopener" style="color: inherit; font-weight: 600">Política de privacidade</a>.
+          ⚠️ As peças selecionadas são enviadas à API do provedor do modelo escolhido (Anthropic, Google ou OpenAI). Processos podem conter dados pessoais/sigilosos — use conforme as normas do seu tribunal. <a href="https://github.com/marcosmarf27/pje-ia/blob/main/PRIVACY.md" target="_blank" rel="noopener" style="color: inherit; font-weight: 600">Política de privacidade</a>.
         </div>
       </div>
     </div>

--- a/src/popup.html
+++ b/src/popup.html
@@ -30,7 +30,7 @@
       <img src="../icons/icon48.png" alt="" />
       <div>
         <div class="t">TecJustiça PJe</div>
-        <div class="s">Análise de autos com IA — Claude ou Gemini</div>
+        <div class="s">Análise de autos com IA — Claude, Gemini ou GPT</div>
       </div>
     </div>
 
@@ -71,6 +71,20 @@
         </div>
       </details>
 
+      <details class="keybox" id="boxO">
+        <summary>
+          Chave da API — OpenAI (GPT)
+          <span class="kstate" id="kstateO">não configurada</span>
+        </summary>
+        <div class="keybox-in">
+          <div class="pw-row">
+            <input id="openaiApiKey" type="password" placeholder="sk-..." autocomplete="off" aria-label="Chave da API da OpenAI" />
+            <button class="toggle-pw" id="togglePwO" type="button">mostrar</button>
+          </div>
+          <span class="hint">Opcional. Crie em platform.openai.com — <a href="help.html#openai" target="_blank">passo a passo →</a></span>
+        </div>
+      </details>
+
       <label class="field" for="model">Modelo</label>
       <select id="model">
         <optgroup label="Claude (Anthropic)">
@@ -82,6 +96,11 @@
         <optgroup label="Gemini (Google)">
           <option value="gemini-3.6-flash">Gemini 3.6 Flash (1M tokens — rápido)</option>
           <option value="gemini-3.5-flash-lite">Gemini 3.5 Flash-Lite (1M tokens — o mais barato)</option>
+        </optgroup>
+        <optgroup label="GPT (OpenAI)">
+          <option value="gpt-5.6-luna">GPT-5.6 Luna (1M tokens — rápido e barato)</option>
+          <option value="gpt-5.6-terra">GPT-5.6 Terra (1M tokens — equilibrado)</option>
+          <option value="gpt-5.6-sol">GPT-5.6 (Sol — o mais capaz)</option>
         </optgroup>
       </select>
 
@@ -96,7 +115,7 @@
       </div>
 
       <label class="field" for="customPrompt">Instruções personalizadas (opcional)
-        <span class="hint">Quem você é e como quer as respostas — vale para Claude e Gemini.</span>
+        <span class="hint">Quem você é e como quer as respostas — vale para Claude, Gemini e GPT.</span>
       </label>
       <textarea id="customPrompt" rows="2" maxlength="4000" placeholder="Ex.: Sou advogado(a) da parte autora; aponte riscos e teses favoráveis…"></textarea>
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,5 +1,6 @@
 const apiKeyEl = document.getElementById("apiKey");
 const geminiKeyEl = document.getElementById("geminiApiKey");
+const openaiKeyEl = document.getElementById("openaiApiKey");
 const modelEl = document.getElementById("model");
 const effortEl = document.getElementById("effort");
 const customEl = document.getElementById("customPrompt");
@@ -9,39 +10,51 @@ const chip = document.getElementById("chip");
 const chipText = document.getElementById("chipText");
 const togglePw = document.getElementById("togglePw");
 const togglePwG = document.getElementById("togglePwG");
+const togglePwO = document.getElementById("togglePwO");
 // Elementos só do layout novo — este script é COMPARTILHADO por popup.html e
 // options.html, então tudo o que uma página tem e a outra não é opcional.
 const kstateA = document.getElementById("kstateA");
 const kstateG = document.getElementById("kstateG");
+const kstateO = document.getElementById("kstateO");
 const firstRun = document.getElementById("firstRun");
 const abrirOpcoes = document.getElementById("abrirOpcoes");
 const boxA = document.getElementById("boxA");
 const boxG = document.getElementById("boxG");
+const boxO = document.getElementById("boxO");
 
-// O chip reflete a chave do PROVEDOR do modelo selecionado: escolher um
-// modelo Gemini sem chave do Google (ou Claude sem chave Anthropic) avisa
-// na hora, antes mesmo de salvar.
-function ehGemini() {
-  return String(modelEl.value || "").startsWith("gemini-");
+// O chip reflete a chave do PROVEDOR do modelo selecionado: escolher um modelo
+// de um provedor sem a chave dele avisa na hora, antes mesmo de salvar. O
+// provedor sai do prefixo do id (mesma regra do background.js/content.js).
+function provedorDoModelo() {
+  const m = String(modelEl.value || "");
+  if (m.startsWith("gemini-")) return "gemini";
+  if (m.startsWith("gpt-")) return "openai";
+  return "anthropic";
 }
+function campoDoProvedor(p) {
+  return p === "gemini" ? geminiKeyEl : p === "openai" ? openaiKeyEl : apiKeyEl;
+}
+const NOME_PROVEDOR = { anthropic: "Anthropic", gemini: "Google", openai: "OpenAI" };
 // Nome curto do modelo escolhido ("Claude Haiku 4.5"), tirado do próprio
 // <option> — sem duplicar aqui a tabela de nomes que já está no HTML.
 function nomeDoModelo() {
   const op = modelEl.selectedOptions && modelEl.selectedOptions[0];
   return op ? op.textContent.split(" (")[0].trim() : modelEl.value;
 }
+function temChaveDigitada(el) {
+  return !!(el && el.value.trim());
+}
 function setChip() {
-  const gemini = ehGemini();
-  const temChave = gemini ? !!geminiKeyEl.value.trim() : !!apiKeyEl.value.trim();
+  const prov = provedorDoModelo();
+  const temChave = temChaveDigitada(campoDoProvedor(prov));
   chip.className = "status-chip " + (temChave ? "ok" : "warn");
   chipText.textContent = temChave
     ? "Pronto para usar — " + nomeDoModelo()
-    : gemini
-      ? "Falta a chave do Google para este modelo"
-      : "Falta a chave da Anthropic para este modelo";
+    : "Falta a chave da " + NOME_PROVEDOR[prov] + " para este modelo";
   // estado de cada chave, independente do modelo ativo
   marcarChave(kstateA, apiKeyEl.value);
   marcarChave(kstateG, geminiKeyEl.value);
+  marcarChave(kstateO, openaiKeyEl && openaiKeyEl.value);
 }
 function marcarChave(el, valor) {
   if (!el) return;
@@ -51,24 +64,27 @@ function marcarChave(el, valor) {
 }
 
 // Abre a chave que FALTA para o modelo ativo — no carregamento E a cada troca
-// de modelo: sem isto, escolher um modelo Gemini sem chave do Google mostrava
-// o aviso com o campo recolhido, e a linha fechada não parece clicável para
-// quem nunca a abriu. Só ABRE (as chaves nascem fechadas no HTML): fechar o
-// que o usuário abriu na mão seria hostil.
+// de modelo: sem isto, escolher um modelo de um provedor sem chave mostrava o
+// aviso com o campo recolhido, e a linha fechada não parece clicável para quem
+// nunca a abriu. Só ABRE (as chaves nascem fechadas no HTML): fechar o que o
+// usuário abriu na mão seria hostil.
 function abrirChaveQueFalta() {
-  const gemini = ehGemini();
+  const prov = provedorDoModelo();
   const faltaA = !apiKeyEl.value.trim();
   const faltaG = !geminiKeyEl.value.trim();
-  const primeiroUso = faltaA && faltaG;
-  if (boxA && faltaA && (primeiroUso || !gemini)) boxA.open = true;
-  if (boxG && faltaG && (primeiroUso || gemini)) boxG.open = true;
+  const faltaO = !(openaiKeyEl && openaiKeyEl.value.trim());
+  const primeiroUso = faltaA && faltaG && faltaO;
+  if (boxA && faltaA && (primeiroUso || prov === "anthropic")) boxA.open = true;
+  if (boxG && faltaG && (primeiroUso || prov === "gemini")) boxG.open = true;
+  if (boxO && faltaO && (primeiroUso || prov === "openai")) boxO.open = true;
 }
 
 chrome.storage.local.get(
-  ["apiKey", "geminiApiKey", "model", "effort", "customPrompt"],
+  ["apiKey", "geminiApiKey", "openaiApiKey", "model", "effort", "customPrompt"],
   (v) => {
     if (v.apiKey) apiKeyEl.value = v.apiKey;
     if (v.geminiApiKey) geminiKeyEl.value = v.geminiApiKey;
+    if (openaiKeyEl && v.openaiApiKey) openaiKeyEl.value = v.openaiApiKey;
     if (v.model) modelEl.value = v.model;
     if (effortEl && v.effort) effortEl.value = v.effort;
     if (customEl && v.customPrompt) customEl.value = v.customPrompt;
@@ -77,12 +93,13 @@ chrome.storage.local.get(
     // quando eles servem, e é o que faz o popup caber sem rolagem depois.
     // O critério é o que está SALVO (não o que está sendo digitado) — sumir no
     // meio da digitação seria um salto de layout no meio da tarefa.
-    if (firstRun && (v.apiKey || v.geminiApiKey)) firstRun.hidden = true;
+    if (firstRun && (v.apiKey || v.geminiApiKey || v.openaiApiKey)) firstRun.hidden = true;
     abrirChaveQueFalta();
   }
 );
 
 function ligarToggle(btn, input) {
+  if (!btn || !input) return;
   btn.addEventListener("click", () => {
     const showing = input.type === "text";
     input.type = showing ? "password" : "text";
@@ -91,6 +108,7 @@ function ligarToggle(btn, input) {
 }
 ligarToggle(togglePw, apiKeyEl);
 ligarToggle(togglePwG, geminiKeyEl);
+ligarToggle(togglePwO, openaiKeyEl);
 
 modelEl.addEventListener("change", () => {
   setChip();
@@ -98,6 +116,7 @@ modelEl.addEventListener("change", () => {
 });
 apiKeyEl.addEventListener("input", setChip);
 geminiKeyEl.addEventListener("input", setChip);
+if (openaiKeyEl) openaiKeyEl.addEventListener("input", setChip);
 
 // "Configuração completa" (só no popup): a página de opções tem as mesmas
 // preferências com as explicações longas e espaço para escrever as instruções
@@ -113,14 +132,15 @@ if (abrirOpcoes) {
 saveBtn.addEventListener("click", () => {
   const apiKey = apiKeyEl.value.trim();
   const geminiApiKey = geminiKeyEl.value.trim();
-  const cfg = { apiKey, geminiApiKey, model: modelEl.value };
+  const openaiApiKey = openaiKeyEl ? openaiKeyEl.value.trim() : "";
+  const cfg = { apiKey, geminiApiKey, openaiApiKey, model: modelEl.value };
   if (effortEl) cfg.effort = effortEl.value;
   if (customEl) cfg.customPrompt = customEl.value.trim();
   chrome.storage.local.set(cfg, () => {
     setChip();
     // salvou a primeira chave: os passos de primeiro uso cumpriram seu papel
-    if (firstRun && (apiKey || geminiApiKey)) firstRun.hidden = true;
-    const temChaveDoModelo = ehGemini() ? !!geminiApiKey : !!apiKey;
+    if (firstRun && (apiKey || geminiApiKey || openaiApiKey)) firstRun.hidden = true;
+    const temChaveDoModelo = temChaveDigitada(campoDoProvedor(provedorDoModelo()));
     saveStatus.textContent = temChaveDoModelo
       ? "Configuração salva ✓"
       : "Salvo — falta a chave do provedor do modelo escolhido.";


### PR DESCRIPTION
## Objetivo

Adicionar a **OpenAI (GPT)** como **terceiro provedor de IA** da extensão, ao lado de Anthropic (Claude) e Google (Gemini), com suporte aos modelos **GPT-5.6 Luna**, **GPT-5.6 Terra** e **GPT-5.6 (Sol)** — usando a **Responses API** atual (`POST /v1/responses`, GA, sem header beta).

**Sem regressão** é o requisito central: tudo que funciona hoje com Claude e Gemini funciona igual com a OpenAI — análise de documentos (PDF), uso modal, minutar/editor, mapa mental, busca de jurisprudência, medidor de contexto/custo e cache automático.

## Como foi feito (arquitetura preservada)

A extensão já tinha uma abstração limpa de dois provedores: `claude.js` e `gemini.js` são clientes irmãos que emitem o **mesmo vocabulário de eventos** (`text`/`thinking`/`citation`/`tool`/`trunc`/`final`), e o `background.js` despacha por `providerDe(model)`. Adicionei um **terceiro irmão**, `src/openai.js`, seguindo exatamente esse padrão — `claude.js` fica **intocado**.

### Núcleo — `src/openai.js`
- **Modo stateless** (`store:false`): o histórico canônico (blocos estilo Anthropic) é traduzido **no request** por `traduzirHistorico`; o filtro de peças desmarcadas (`prepararEnvio`) continua funcionando igual.
- **Raciocínio criptografado**: cada item `{type:"reasoning", encrypted_content}` volta **verbatim** via wrapper opaco `x-openai-item` — análogo ao *thinking* assinado da Anthropic e ao `thought_signature` do Gemini. O request declara `include:["reasoning.encrypted_content"]` e `reasoning:{effort, summary:"auto", context:"all_turns"}`.
- **`usage` normalizado** para as 4 categorias da Anthropic → custo, tooltip e medidor funcionam sem mudança.
- **Files API** (`purpose:"user_data"`), com namespace de cache próprio (`ofile:`) para nunca misturar `file_id` entre provedores.
- **countTokens exato** via `POST /v1/responses/input_tokens` → a guarda de 90% do contexto fica precisa.
- **Citações textuais** (`citacoesNativas:false`, como o Gemini): `url_citation` da busca vira citação web; sem marcadores `[n]` por página.

### Effort (o ponto levantado sobre "MAX")
A escala da OpenAI é a mais rica dos três: `none | minimal | low | medium | high | xhigh | max` (+ um eixo separado `reasoning.mode`). O suporte a `xhigh`/`max` é **dependente da variante e não documentado por modelo** (Luna/Terra podem rejeitar com 400). Por isso `EFFORT_PARA_OPENAI` mapeia os três níveis da extensão para o subconjunto **comum e seguro** `low/medium/high`, aceito por todas as variantes 5.6 e por todos os provedores. Expor `xhigh`/`max` no futuro é um ponto único de mudança (provavelmente só no Sol).

### Integração
- **`background.js`**: `MODEL_CAPS` dos três GPT-5.6, `providerDe` (prefixo `gpt-`), chave `openaiApiKey`, dispatch do `streamFn`, handlers de `upload`/`countTokens` e mapeamento de effort.
- **`content.js`**: `toolsBusca` (`web_search`), teto de base64 da OpenAI, `refreshKey`/alerta de troca de provedor/nome do provedor cientes de **três** provedores; `cache_control` só no Anthropic.
- **`manifest.json`**: `https://api.openai.com/*` em `host_permissions`.
- **popup / options / help**: terceiro campo de chave (`sk-...`), `<optgroup>` com os modelos GPT e textos atualizados.

## Preço e limites (por 1M de tokens)

| Modelo | Contexto | Preço (in / out) | Perfil |
|---|---|---|---|
| GPT-5.6 Luna | 1,05M | 0,20 / 1,20 | Rápido e econômico |
| GPT-5.6 Terra | 1,05M | 2 / 12 | Equilibrado |
| GPT-5.6 (Sol) | 1,05M | 5 / 30 | O mais capaz |

## Testes

- `node --check` em todos os `src/*.js` e validação do `manifest.json` — OK.
- Teste de unidade no scratchpad (fetch falso com `ReadableStream` de eventos SSE simulados): **41 asserts** cobrindo o acumulador SSE (deltas de texto/raciocínio, tool, citação web, `final`, `usage` normalizado, truncamento, queda sem `completed`) e a tradução de histórico (reasoning **verbatim**; garantia de que `__pecaId`, `cache_control` e `citations` **nunca vazam** para o request). Todos passam.

## Notas de verificação
- IDs de modelo (`gpt-5.6-sol|terra|luna`) e preços conferidos na documentação oficial da OpenAI (agosto/2026). Como preços e o suporte por variante ao effort `xhigh/max` podem mudar, valem uma reconferência antes de publicar.
