### PR TITLE
feat(chat): peças com erro não travam o chat, anexos no input e adicionar peça citada

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -3251,7 +3251,8 @@
     if (d.kind === "pdf") return "PDF · " + (d.pages || 1) + (d.pages === 1 ? " pág." : " págs.");
     if (d.kind === "img") return (d.fmt || "imagem").toUpperCase();
     const kb = Math.max(1, Math.round((d.size || (d.text ? d.text.length : 0)) / 1024));
-    const rot = d.fmt === "html" ? "HTML" : d.fmt === "docx" ? "Word" : "Texto";
+    const rot =
+      d.fmt === "html" ? "HTML" : d.fmt === "docx" ? "Word" : d.fmt === "rtf" ? "RTF" : "Texto";
     return rot + " · " + kb + " KB";
   }
 

--- a/src/content.js
+++ b/src/content.js
@@ -1465,14 +1465,21 @@
     return true;
   }
 
-  // Dá para anexar esta peça ao request AGORA, do jeito que ela está?
+  // Dá para anexar esta peça (ou ANEXO do input) ao request AGORA, do jeito que
+  // ela está?
+  //
+  // Lê por `entradaDoc`, NÃO por `docsCache` direto: `montarBlocos` chama isto
+  // também para os anexos do input, que vivem só na Map `anexos`. Ler o
+  // `docsCache` cru fazia todo anexo cair em `semConteudo` ("o envio anterior
+  // expirou") e nunca chegar ao modelo. Para uma peça de verdade `entradaDoc`
+  // devolve a MESMA entrada do `docsCache`, então o comportamento não muda.
   //
   // A resposta depende de COMO cada tipo viaja, e por isso os ramos são
   // explícitos: só o PDF tem a rota por referência (Files API). A IMAGEM vai
   // sempre em base64 inline nos três provedores — um fileId não a dispensa de
   // nada, e tratá-la junto do PDF faria uma peça sem bytes parecer pronta.
   function podeAnexar(id) {
-    const d = docsCache.get(id);
+    const d = entradaDoc(id);
     if (!d) return false;
     if (d.kind === "text") return !!d.text;
     if (d.kind === "img") return !!d.b64;
@@ -1838,7 +1845,7 @@
   function pecasTruncadas(ids) {
     const out = [];
     for (const id of ids) {
-      const d = docsCache.get(id);
+      const d = entradaDoc(id); // peça (docsCache) ou anexo (.md/.txt longo)
       if (d && d.kind === "text" && d.text && d.text.length > MAX_CHARS_TEXTO) {
         out.push({
           id,
@@ -2897,9 +2904,9 @@
           dica: "Envie a mensagem de novo — elas serão baixadas e reenviadas.",
         });
       }
-      // Peças que entraram CORTADAS. Só as deste turno: as dos turnos
-      // anteriores já foram reportadas quando entraram.
-      const cortadas = pecasTruncadas(anexadas);
+      // Peças (e anexos de texto) que entraram CORTADAS. Só os deste turno: os
+      // dos turnos anteriores já foram reportados quando entraram.
+      const cortadas = pecasTruncadas([...anexadas, ...anexosNovos]);
       if (cortadas.length) {
         panel.mostrarFalhasPecas(cortadas, avisoTrunc(cortadas.length));
       }

--- a/src/content.js
+++ b/src/content.js
@@ -3211,7 +3211,26 @@
     if (d.kind === "pdf") return "PDF · " + (d.pages || 1) + (d.pages === 1 ? " pág." : " págs.");
     if (d.kind === "img") return (d.fmt || "imagem").toUpperCase();
     const kb = Math.max(1, Math.round((d.size || (d.text ? d.text.length : 0)) / 1024));
-    return (d.fmt === "html" ? "HTML" : "Texto") + " · " + kb + " KB";
+    const rot = d.fmt === "html" ? "HTML" : d.fmt === "docx" ? "Word" : "Texto";
+    return rot + " · " + kb + " KB";
+  }
+
+  // Lê o arquivo anexado. PDF/TXT/MD (e imagem) passam pelo MESMO extrator das
+  // peças (`PJE.lerAnexo` → `lerCorpo`); o .docx é caso à parte porque NENHUM
+  // dos três provedores o lê nativamente como documento (só PDF tem a rota de
+  // visão/análise de documento) — então extraímos o TEXTO no cliente com o
+  // `DocxImport` que a extensão já usa para importar peças-modelo, e ele entra
+  // como bloco de texto igual a um .txt/.md. `DocxImport` é opcional (mesma
+  // guarda do painel): sem ele, o .docx cai no `lerAnexo`, que o recusa com
+  // motivo (é um ZIP → binário).
+  async function lerArquivoAnexo(file) {
+    const nome = String((file && file.name) || "").toLowerCase();
+    if ((nome.endsWith(".docx") || nome.endsWith(".doc")) && typeof DocxImport !== "undefined") {
+      // lerArquivo já lança mensagem clara para .doc (Word 97-2003) e vazio.
+      const texto = await DocxImport.lerArquivo(file);
+      return { kind: "text", fmt: "docx", text: texto, size: (file && file.size) || texto.length };
+    }
+    return PJE.lerAnexo(file);
   }
 
   // Reprojeta os anexos no painel (chips). O painel é só reflexo — a fonte de
@@ -3260,7 +3279,7 @@
           continue;
         }
         try {
-          const corpo = await PJE.lerAnexo(file);
+          const corpo = await lerArquivoAnexo(file);
           const id = "anexo:" + ++anexoSeq;
           const nomeCurto = (file.name || "arquivo").replace(/\.[^.]+$/, "");
           anexos.set(id, Object.assign({}, corpo, { id, nome: file.name, titulo: "Anexo — " + nomeCurto }));
@@ -3277,7 +3296,7 @@
       if (falhas.length) {
         panel.mostrarFalhasPecas(falhas, {
           titulo: falhas.length === 1 ? "1 arquivo não pôde ser anexado" : falhas.length + " arquivos não puderam ser anexados",
-          dica: "A extensão anexa PDF, TXT e Markdown (.md). Verifique o formato e o tamanho e tente de novo.",
+          dica: "A extensão anexa PDF, Word (.docx), TXT e Markdown (.md). Verifique o formato e o tamanho e tente de novo.",
         });
       }
     });

--- a/src/content.js
+++ b/src/content.js
@@ -382,6 +382,34 @@
     return docsCache.get(id) || anexos.get(id);
   }
 
+  // Um bloco do histórico é de anexo do input quando o `__pecaId` sintético
+  // começa por "anexo:". Usado para (a) removê-los na retomada — os bytes são de
+  // sessão e o `file_id` já venceu — e (b) NÃO gravar os bytes no disco.
+  function ehBlocoAnexo(b) {
+    return b && typeof b.__pecaId === "string" && b.__pecaId.indexOf("anexo:") === 0;
+  }
+
+  // Cópia do `conversation` pronta para o disco: os blocos de anexo do input
+  // carregam o base64 do PDF ou o TEXTO extraído do arquivo do usuário, e gravar
+  // isso é justamente o que a extensão evita (a mesma regra do b64 das peças —
+  // ver casodb.js e `salvarPecas`). Como `aplicarConversa` já os REMOVE na
+  // retomada, persistir os bytes seria guardar o que nunca será reusado; e como
+  // a memória de caso não os re-hidrata, o `file_id` deles estaria morto de todo
+  // jeito. Trocamos cada bloco de anexo por um STUB sem bytes que preserva só o
+  // `__pecaId` — assim a retomada ainda os detecta (para avisar "reanexe os
+  // arquivos"), mas nenhum byte do arquivo do usuário toca o disco. O
+  // `conversation` VIVO (que vai à API neste sessão) fica intocado.
+  function conversaParaDisco() {
+    return conversation.map((turno) => {
+      if (!Array.isArray(turno.content) || !turno.content.some(ehBlocoAnexo)) return turno;
+      return Object.assign({}, turno, {
+        content: turno.content.map((b) =>
+          ehBlocoAnexo(b) ? { __pecaId: b.__pecaId, _anexoStub: true } : b
+        ),
+      });
+    });
+  }
+
   let conversation = []; // [{role, content}]
   let custoConversaUsd = 0; // soma dos custos estimados dos turnos (US$)
 
@@ -577,7 +605,8 @@
   // o caso inteiro junto seria trabalho à toa.
   function snapshotConversa() {
     return {
-      conversation,
+      // sem os bytes dos anexos do input (ver `conversaParaDisco`)
+      conversation: conversaParaDisco(),
       pecasNaConversa: [...pecasNaConversa],
       transcript: panel.lerTranscript ? panel.lerTranscript() : [],
       // `selecaoEfetiva` e não `getSelected`: inclui as peças restauradas que
@@ -2791,6 +2820,15 @@
       // falhas viram relatório (o usuário não perde a pergunta que já digitou).
       const idsNovosParaBlocos = [...anexadas, ...anexosNovos];
       if (!idsNovosParaBlocos.length && !pecasNaConversa.size) {
+        // Caso degenerado: tudo falhou, sem histórico e sem anexo. O turno cai
+        // aqui e o relatório detalhado abaixo (com o desmarcar) NÃO chega a
+        // rodar — o throw vai direto ao catch. Ainda assim a peça que falhou
+        // PRECISA sair da seleção: senão o próximo envio repete a MESMA falha,
+        // que é exatamente o "peça trava o chat" que este fluxo existe para
+        // impedir. O erro abaixo já diz o motivo; remarcar a peça é nova
+        // tentativa. (desmarcar durante `busy` é seguro — `onSelectionChange`
+        // retorna cedo, como no desmarcar do caminho normal.)
+        if (falhasDownload.length) panel.desmarcarPecas(falhasDownload.map((f) => f.id));
         throw new Error(
           falhasDownload.length === 1
             ? 'não foi possível baixar "' + falhasDownload[0].titulo + '" — ' + falhasDownload[0].erro
@@ -2926,8 +2964,10 @@
         // FALHOU (ex.: 429 após muitos uploads). Nos dois, re-pinta com a
         // estimativa local — o cache agora tem todas as peças baixadas, então o
         // número é decente. Sem isto o medidor ficaria CONGELADO no retrato de
-        // quando a seleção foi feita ("N peça(s) sem medir", 0%).
-        mostrarEstimativaLocal(selectedIds);
+        // quando a seleção foi feita ("N peça(s) sem medir", 0%). Inclui os
+        // anexos do input (como todo outro ponto de medição), senão o gauge
+        // subcontaria os já enviados nos turnos de acompanhamento.
+        mostrarEstimativaLocal([...selectedIds, ...anexos.keys()]);
         // Pular só acontece com folga larga sobre a janela — o que significa
         // que qualquer alerta de contexto cheio anterior está resolvido. Falha
         // do count_tokens não diz nada sobre isso, então ali o alerta fica.
@@ -4327,14 +4367,13 @@
     // API, e `conversation = undefined` derrubaria o próximo `.length` — que é
     // lido em quase todo caminho do envio.
     conversation = Array.isArray(caso.conversation) ? caso.conversation : [];
-    // Anexos do input são de SESSÃO: seus bytes não vão ao disco, então numa
-    // conversa retomada os blocos deles apontariam para uploads que não voltam
-    // (e o base64, se fosse o caso, nem foi guardado). Tira-os do histórico aqui
-    // — senão o `file_id` morto daria 400 no primeiro envio — e avisa, para o
-    // usuário saber que pode reanexá-los. Peças do PJe continuam intactas: elas
-    // se re-baixam e `revalidarPecasDoHistorico` cuida dos uploads vencidos.
-    const ehBlocoAnexo = (b) =>
-      b && typeof b.__pecaId === "string" && b.__pecaId.indexOf("anexo:") === 0;
+    // Anexos do input são de SESSÃO: seus bytes não vão ao disco (o snapshot já
+    // os salva como stub sem bytes — ver `conversaParaDisco`), então numa
+    // conversa retomada os blocos deles apontariam para uploads que não voltam.
+    // Tira-os do histórico aqui — senão o stub/`file_id` morto sujaria o request
+    // — e avisa, para o usuário saber que pode reanexá-los. Peças do PJe
+    // continuam intactas: elas se re-baixam e `revalidarPecasDoHistorico` cuida
+    // dos uploads vencidos. (`ehBlocoAnexo` é o mesmo predicado do snapshot.)
     let anexosRetomados = 0;
     for (const turno of conversation) {
       if (!Array.isArray(turno.content)) continue;

--- a/src/content.js
+++ b/src/content.js
@@ -382,6 +382,19 @@
     return docsCache.get(id) || anexos.get(id);
   }
 
+  // Seleção de peças MAIS os anexos do input — o conjunto que de fato vai ao
+  // modelo, e portanto o único conjunto que se pode MEDIR.
+  //
+  // Existe como função porque a distinção importa e é fácil de errar: tudo que
+  // MEDE (estimativa local, páginas, `ativos` do pré-voo, gauge) precisa dos
+  // anexos; tudo que BAIXA (`precisaBaixar`, `baixarQuieto`, `subirPecas`,
+  // `revalidarPecasDoHistorico`) precisa ficar SÓ com as peças — um id
+  // sintético "anexo:1" na fila de download vira uma ida ao PJe atrás de uma
+  // peça que não existe. Por isso os dois conjuntos nunca se fundem num só.
+  function comAnexos(ids) {
+    return anexos.size ? [...ids, ...anexos.keys()] : ids;
+  }
+
   // Um bloco do histórico é de anexo do input quando o `__pecaId` sintético
   // começa por "anexo:". Usado para (a) removê-los na retomada — os bytes são de
   // sessão e o `file_id` já venceu — e (b) NÃO gravar os bytes no disco.
@@ -1718,6 +1731,19 @@
   // não interrompe: o anexo cai no fallback base64 de `montarBlocos` (teto de
   // b64 compartilhado com as peças). Imagem e texto vão sempre inline; só PDF
   // sobe.
+  //
+  // LACUNA CONHECIDA, e ela é estreita de propósito: um anexo PDF já enviado
+  // fica no histórico por `file_id`, e `revalidarPecasDoHistorico` NÃO o
+  // revalida (o `ativos` dela é `selecaoEfetiva()`, que não tem anexo). Se o
+  // usuário TROCAR A CHAVE da API no meio da conversa, aquele `file_id` passa a
+  // ser de outra conta e o turno seguinte leva 400. Não é coberto aqui porque a
+  // saída certa — ensinar aquela função a tratar um segundo tipo de entidade —
+  // mexe na parte mais delicada da memória de caso, e o gatilho é raro (o
+  // provedor já é bloqueado por `conversaProvider`; sobra a troca de conta
+  // DENTRO do mesmo provedor, com PDF anexado, na mesma sessão). "Nova
+  // conversa" resolve. Se for tratar: os bytes do anexo estão sempre em
+  // memória, então basta re-subir e reescrever o `file_id` no bloco — sem
+  // download, que é o passo caro no caso das peças.
   async function subirAnexos(ids) {
     const provAtual = (modelCaps && modelCaps.provider) || "anthropic";
     const pend = ids.filter((id) => {
@@ -1728,7 +1754,6 @@
       );
     });
     if (!pend.length) return;
-    const idProc = PJE.getIdProcesso() || "proc";
     const queue = pend.slice();
     async function w() {
       while (queue.length) {
@@ -1742,7 +1767,18 @@
               filename: d.nome || "anexo-" + id + ".pdf",
               b64: d.b64,
               mime: "application/pdf",
-              cacheKey: idProc + ":" + id + ":" + (d.size || 0),
+              // SEM `cacheKey`, ao contrário de `subirPecas` — e isto não é
+              // esquecimento. Aquele cache vive em `chrome.storage.session`,
+              // que SOBREVIVE ao recarregar a página; os anexos, não (a Map é
+              // de memória e a retomada os descarta). Então ele nunca pode
+              // acertar de forma útil aqui: dentro da sessão quem já evita o
+              // re-upload é o `d.fileId` conferido acima. O que sobrava era só
+              // o risco — `anexo:<n>` reinicia em 1 a cada carga da página,
+              // então o par (processo, "anexo:1", tamanho) de HOJE colide com o
+              // de um arquivo DIFERENTE anexado antes do último F5, e o worker
+              // devolveria o file_id do arquivo velho. O modelo então analisa
+              // um documento que o usuário não anexou, sem nada na tela dizendo
+              // isso — a falha silenciosa que este projeto trata como a pior.
             },
           });
           d.fileId = r.fileId;
@@ -2574,15 +2610,19 @@
     // disparam syncSelection sem mudança real e sobrescreveriam a medição
     // oficial com uma estimativa local defasada.
     if (busy) return;
-    if (!ids.length && !conversation.length) {
+    if (!ids.length && !anexos.size && !conversation.length) {
       estSeq++; // cancela estimativas em voo
       panel.setContexto(null); // nada selecionado e nada conversado: sem medidor
       return;
     }
 
     // Camada 1: resposta IMEDIATA ao clique, com o que já se sabe localmente.
-    if (modelCaps) mostrarEstimativaLocal(ids);
-    else garantirCaps().then(() => !busy && mostrarEstimativaLocal(ids));
+    // `comAnexos`: o que vai ao modelo é seleção MAIS anexos do input, e medir
+    // só a seleção fazia o gauge encolher a cada clique numa peça — o anexo
+    // sumia da conta que ele mesmo tinha acabado de engordar.
+    const idsMedidos = comAnexos(ids);
+    if (modelCaps) mostrarEstimativaLocal(idsMedidos);
+    else garantirCaps().then(() => !busy && mostrarEstimativaLocal(idsMedidos));
 
     // Camada 2: refinamento em segundo plano (downloads + uploads + count).
     estTimer = setTimeout(() => refinarContexto(ids), 900);
@@ -2641,8 +2681,12 @@
     // que é serializada. Duas frentes de download só se atrapalhariam, e as
     // ativações da própria exportação re-disparam este handler o tempo todo.
     if (busy || exportando) return;
+    // O conjunto MEDIDO inclui os anexos do input; o conjunto BAIXADO, não (ver
+    // `comAnexos`). A chave da memoização é a do medido: anexar ou soltar um
+    // arquivo muda o request e precisa re-medir, exatamente como marcar uma peça.
+    const idsMedidos = comAnexos(ids);
     // mesma seleção e mesma conversa da última medição precisa: pula
-    const chave = ids.slice().sort().join(",") + "|" + conversation.length;
+    const chave = idsMedidos.slice().sort().join(",") + "|" + conversation.length;
     if (chave === ultimaChaveEst) return;
     const seq = ++estSeq;
     try {
@@ -2661,7 +2705,7 @@
         // exportação). O que baixar entra no cache e o envio reaproveita; o
         // que não baixar, o envio busca com o card de progresso visível — o
         // comportamento de antes, nunca pior.
-        mostrarEstimativaLocal(ids);
+        mostrarEstimativaLocal(idsMedidos);
         await prefetchProgressivo(ids, faltam, seq);
         return;
       }
@@ -2669,7 +2713,7 @@
       await baixarQuieto(ids, (feitas, total) => {
         if (seq !== estSeq || busy) return;
         panel.setStatus("Medindo o contexto… baixando peças (" + feitas + "/" + total + ")", true);
-        mostrarEstimativaLocal(ids);
+        mostrarEstimativaLocal(idsMedidos);
       });
       if (seq !== estSeq || busy) return;
       // sobe os PDFs à Files API JÁ na medição: o count_tokens referencia
@@ -2680,7 +2724,14 @@
 
       // request PROSPECTIVO: histórico filtrado + um turno de rascunho com
       // as peças novas (as que ainda não têm blocos no histórico)
-      const ativos = new Set(ids);
+      //
+      // `idsMedidos` e não `ids`: `prepararEnvio` trata todo bloco com
+      // `__pecaId` fora de `ativos` como "peça desmarcada" e o REMOVE. Com só a
+      // seleção aqui, os blocos dos anexos do input saíam do histórico do
+      // request medido — o pré-voo media um envio menor que o real, e a guarda
+      // de 90% ficava otimista exatamente quando o usuário tinha acabado de
+      // anexar um PDF grande.
+      const ativos = new Set(idsMedidos);
       // `podeAnexar` e não `has`: uma peça hidratada sem conteúdo utilizável
       // entraria em `montarBlocos` logo abaixo, que a descartaria — e no
       // caminho antigo (b64 ausente) estouraria um TypeError DENTRO deste try,
@@ -2709,9 +2760,9 @@
         panel.setContexto({
           tokens: est.tokens,
           ctxTokens: est.ctxTokens,
-          paginas: paginasDe(ids),
+          paginas: paginasDe(idsMedidos),
           maxPaginas: modelCaps ? modelCaps.maxPages : 0,
-          pecas: ids.length,
+          pecas: idsMedidos.length,
         });
       }
     } catch (e) {
@@ -3288,10 +3339,18 @@
     );
   }
 
-  // Feedback imediato no medidor ao anexar/remover, incluindo os anexos.
+  // Anexar ou soltar um arquivo muda o request tanto quanto marcar uma peça, e
+  // por isso passa pelas MESMAS duas camadas de medição: a estimativa local
+  // imediata e, com o mesmo debounce do clique na lista, o refinamento exato
+  // (count_tokens). Sem a segunda camada o gauge ficava no chute local até o
+  // envio — e um PDF anexado de 300 páginas só apareceria no número no momento
+  // em que já não dava para tirá-lo sem perder a pergunta digitada.
   function reestimarComAnexos() {
     if (busy || !modelCaps) return;
-    mostrarEstimativaLocal([...selecaoEfetiva(), ...anexos.keys()]);
+    clearTimeout(estTimer);
+    const sel = selecaoEfetiva();
+    mostrarEstimativaLocal(comAnexos(sel));
+    estTimer = setTimeout(() => refinarContexto(sel), 900);
   }
 
   // Teto de sanidade por anexo (antes do teto de b64 compartilhado que

--- a/src/content.js
+++ b/src/content.js
@@ -359,6 +359,29 @@
   }
 
   const docsCache = new Map(); // id -> {kind:"pdf",b64,size,pages,fileId?} | {kind:"text",text}
+
+  // ANEXOS DO INPUT — arquivos que o usuário anexa na própria caixa de mensagem
+  // (PDF, TXT, MD), para conversar sobre eles junto das peças do processo, ou
+  // sozinhos. Vivem SÓ na sessão, de propósito: ao contrário das peças, não têm
+  // origem no PJe para re-baixar, e gravar bytes de arquivo do usuário no disco
+  // é justamente o que a extensão evita (a mesma regra do b64 das peças). Cada
+  // anexo ganha um id sintético "anexo:<n>" e uma entrada no mesmo FORMATO do
+  // `docsCache` ({kind, fmt, b64|text, pages…}) — é o que deixa `montarBlocos` e
+  // as contas de página/token tratarem anexo e peça pelo mesmo caminho, via
+  // `entradaDoc`. NUNCA entram no `docsCache` nem na fila de gravação
+  // (`pecasSujas`): o que os distingue de uma peça é só esta Map.
+  const anexos = new Map(); // "anexo:<n>" -> {id, nome, kind, fmt, b64|text, size, pages?, mime?, w?, h?, fileId?, fileProvider?, fileExp?, chaveHash?}
+  let anexoSeq = 0; // gera os ids sintéticos (Date.now/Math.random são proibidos aqui — ver CLAUDE.md)
+  // Anexos ainda NÃO enviados (delta deste turno). Ordenados pela ordem em que o
+  // usuário os soltou; viram parte do histórico ao serem enviados, como as peças.
+  const anexosPendentes = [];
+
+  // A entrada de conteúdo de um id, seja peça (docsCache) ou anexo. Ponto único
+  // para `montarBlocos`, `paginasDe` e afins não precisarem saber a origem.
+  function entradaDoc(id) {
+    return docsCache.get(id) || anexos.get(id);
+  }
+
   let conversation = []; // [{role, content}]
   let custoConversaUsd = 0; // soma dos custos estimados dos turnos (US$)
 
@@ -1206,6 +1229,8 @@
   refresh();
 
   function metaDe(id) {
+    const a = anexos.get(id);
+    if (a) return { id, titulo: a.titulo || a.nome || ("Anexo " + id) };
     return docsIndex.get(id) || { id, titulo: "Peça " + id };
   }
 
@@ -1650,6 +1675,52 @@
     await Promise.all([w(), w()]);
   }
 
+  // Sobe à Files API os ANEXOS PDF do input ainda sem file_id do provedor atual.
+  // Gêmeo enxuto de `subirPecas`, separado de propósito: os anexos não são peças
+  // do PJe, então ficam FORA da fila de gravação da memória de caso (`pecasSujas`
+  // / `agendarSalvar`) — nada de arquivo do usuário vai ao disco. Falha de upload
+  // não interrompe: o anexo cai no fallback base64 de `montarBlocos` (teto de
+  // b64 compartilhado com as peças). Imagem e texto vão sempre inline; só PDF
+  // sobe.
+  async function subirAnexos(ids) {
+    const provAtual = (modelCaps && modelCaps.provider) || "anthropic";
+    const pend = ids.filter((id) => {
+      const d = anexos.get(id);
+      return (
+        d && d.kind === "pdf" && d.b64 &&
+        (!d.fileId || (d.fileProvider || "anthropic") !== provAtual)
+      );
+    });
+    if (!pend.length) return;
+    const idProc = PJE.getIdProcesso() || "proc";
+    const queue = pend.slice();
+    async function w() {
+      while (queue.length) {
+        const id = queue.shift();
+        const d = anexos.get(id);
+        if (!d || !d.b64) continue;
+        try {
+          const r = await rpc({
+            type: "upload",
+            payload: {
+              filename: d.nome || "anexo-" + id + ".pdf",
+              b64: d.b64,
+              mime: "application/pdf",
+              cacheKey: idProc + ":" + id + ":" + (d.size || 0),
+            },
+          });
+          d.fileId = r.fileId;
+          d.fileProvider = r.provider || "anthropic";
+          if (r.exp) d.fileExp = r.exp;
+          if (r.chaveHash) d.chaveHash = r.chaveHash;
+        } catch (e) {
+          console.debug("[PJe IA] upload do anexo", id, "falhou; usando base64:", e && e.message);
+        }
+      }
+    }
+    await Promise.all([w(), w()]);
+  }
+
   // Tokens de um anexo em imagem: a fórmula da Anthropic é largura × altura / 750 (o Gemini cobra por
   // ladrilhos e a OpenAI por tiles — a mesma ordem de grandeza, e o count_tokens
   // do pré-voo corrige de graça). `pje.js` já entrega a imagem reduzida a 1568px
@@ -1669,7 +1740,7 @@
   function paginasDe(ids) {
     let total = 0;
     for (const id of ids) {
-      const d = docsCache.get(id);
+      const d = entradaDoc(id);
       if (d && d.kind === "pdf") total += d.pages || 1;
     }
     return total;
@@ -1881,7 +1952,7 @@
     // File API do Google num request Anthropic (ou o inverso) daria 400
     const provAtual = (modelCaps && modelCaps.provider) || "anthropic";
     for (const id of ids) {
-      const d = docsCache.get(id);
+      const d = entradaDoc(id);
       // Peça sem conteúdo no cache (download falhou) é PULADA, nunca uma
       // exceção: os chamadores já filtram, mas um TypeError aqui derrubaria o
       // turno inteiro por causa de uma peça — exatamente o que a tolerância a
@@ -2044,6 +2115,33 @@
       k === alvo ? Object.assign({}, b, { text: b.text + txt }) : b
     );
     return msgs.slice(0, i).concat([{ role: "user", content }]);
+  }
+
+  // Peças que a RESPOSTA citou como faltantes: ids que o modelo escreveu no
+  // texto (tipicamente num aviso "o comprovante está na peça 214661494, que não
+  // foi anexada") mas que NÃO estão no contexto. Viram botões de "adicionar"
+  // abaixo da bolha — o modelo já apontou a peça, o clique poupa procurá-la.
+  //
+  // Só entram ids que são peça REAL desta timeline (`docsIndex`): comparar
+  // contra ela é o que elimina os falsos positivos (um valor, uma data, um
+  // número de lei que por acaso tenha 6+ dígitos quase nunca casa um id real).
+  // Já-no-contexto (marcadas ou no histórico) ficam de fora. Teto de sanidade.
+  function pecasCitadasFaltantes(texto) {
+    if (!texto) return [];
+    const jaTem = new Set([...selecaoEfetiva(), ...pecasNaConversa]);
+    const vistos = new Set();
+    const out = [];
+    const re = /\d{6,}/g;
+    let m;
+    while ((m = re.exec(texto))) {
+      const id = m[0];
+      if (vistos.has(id)) continue;
+      vistos.add(id);
+      if (!docsIndex.has(id) || jaTem.has(id)) continue;
+      out.push({ id, titulo: metaDe(id).titulo });
+      if (out.length >= 12) break;
+    }
+    return out;
   }
 
   // Abre um canal com o worker e resolve quando o turno termina.
@@ -2337,7 +2435,7 @@
     const tokensPagina =
       (modelCaps && modelCaps.tokensPagina) || TOKENS_POR_PAGINA_PDF;
     for (const id of ids) {
-      const d = docsCache.get(id);
+      const d = entradaDoc(id); // peça (docsCache) ou anexo do input
       // peça ainda não baixada: entra na conta quando o download chegar.
       // Contá-la como 0 seria pior — o gauge afirmaria um tamanho que não é o
       // do envio (por isso o gauge também mostra quantas ficaram sem medir).
@@ -2423,8 +2521,9 @@
       maxPaginas: modelCaps.maxPages,
       pecas: ids.length,
       // peças ainda sem download não têm medida — o gauge avisa em vez de
-      // fingir precisão
-      pendentes: ids.filter((id) => !docsCache.has(id)).length,
+      // fingir precisão. Anexos do input já vêm com o conteúdo em mãos, então
+      // nunca contam como "sem medir".
+      pendentes: ids.filter((id) => !docsCache.has(id) && !anexos.has(id)).length,
     });
   }
 
@@ -2608,13 +2707,16 @@
     const selectedIds = selecaoEfetiva().length
       ? selecaoEfetiva()
       : selectedIdsDoPainel;
-    // A guarda só vale para conversa NOVA. Com peças já no histórico, perguntar
-    // sem marcar nada é legítimo — e numa conversa RETOMADA cujas rows ainda
-    // não carregaram era o caso comum: o usuário via a conversa de volta,
+    // Anexos do input que ainda não foram enviados (delta deste turno).
+    const anexosNovos = anexosPendentes.slice();
+    // A guarda só vale para conversa NOVA e SEM anexo. Com peças já no histórico,
+    // perguntar sem marcar nada é legítimo — e numa conversa RETOMADA cujas rows
+    // ainda não carregaram era o caso comum: o usuário via a conversa de volta,
     // digitava e levava um "marque ao menos uma peça" sobre um processo que ele
-    // acabara de ver analisado.
-    if (selectedIds.length === 0 && !pecasNaConversa.size) {
-      panel.setStatus("Marque ao menos uma peça — na lista acima ou digitando @ no campo.");
+    // acabara de ver analisado. Um anexo no input também basta: dá para trabalhar
+    // só com os arquivos anexados, sem marcar peça nenhuma.
+    if (selectedIds.length === 0 && !pecasNaConversa.size && !anexosNovos.length) {
+      panel.setStatus("Marque uma peça, anexe um arquivo (📎) ou digite @ para citar uma peça.");
       return;
     }
     // Troca de provedor no meio da conversa: bloqueia ANTES de qualquer
@@ -2631,17 +2733,19 @@
     clearTimeout(estTimer);
     estSeq++; // o envio faz a estimativa oficial — mata estimativas em voo
 
-    // Anexo INCREMENTAL: só as peças que ainda não estão no histórico entram
-    // neste turno. As já enviadas continuam valendo (fazem parte do prefixo
-    // cacheado da conversa) — reanexá-las duplicaria páginas e tokens.
+    // Anexo INCREMENTAL: só as peças (e anexos) que ainda não estão no histórico
+    // entram neste turno. Os já enviados continuam valendo (fazem parte do
+    // prefixo cacheado da conversa) — reanexá-los duplicaria páginas e tokens.
     const novas = selectedIds.filter((id) => !pecasNaConversa.has(id));
-    const attach = novas.length > 0;
-    // mostra na mensagem quais peças ENTRAM no contexto neste turno
-    panel.addMessage(
-      "user",
-      text,
-      attach ? novas.map((id) => metaDe(id).titulo) : null
-    );
+    const attach = novas.length > 0 || anexosNovos.length > 0;
+    // mostra na mensagem o que ENTRA no contexto neste turno — peças e anexos
+    const atts = attach
+      ? [
+          ...novas.map((id) => metaDe(id).titulo),
+          ...anexosNovos.map((id) => "📎 " + metaDe(id).titulo),
+        ]
+      : null;
+    panel.addMessage("user", text, atts);
     panel.lockInput(true);
     panel.setStatus("");
 
@@ -2666,27 +2770,41 @@
       await revalidarPecasDoHistorico(new Set(selecaoEfetiva()));
       let userContent;
       let paginas = 0;
-      if (attach) {
+      if (attach && novas.length) {
         const r = await baixarSelecionadas(novas);
         anexadas = r.ok;
         falhasDownload = r.falhas;
-        // Todas falharam: aí não há análise possível. Uma OU OUTRA falhando não
-        // pode derrubar o turno — o usuário perde a pergunta que já digitou e
-        // tem de adivinhar qual peça remover.
-        if (!anexadas.length) {
-          throw new Error(
-            falhasDownload.length === 1
-              ? 'não foi possível baixar "' + falhasDownload[0].titulo + '" — ' + falhasDownload[0].erro
-              : "nenhuma das " + falhasDownload.length + " peças novas pôde ser baixada"
-          );
-        }
-        // a guarda conta o que VAI no request: só as peças ativas (marcadas)
-        paginas = guardaPaginas(selectedIds);
-        await subirPecas(anexadas);
-        stripOldCacheControl();
-        userContent = [...montarBlocos(anexadas), { type: "text", text }];
       } else {
-        paginas = guardaPaginas(selectedIds);
+        anexadas = [];
+      }
+      // Peça que falha no download NÃO pode travar o próximo turno: ela é tirada
+      // da seleção mais abaixo (`desmarcarPecas`), então aqui só decidimos se há
+      // algo a analisar. "Nada baixou" só derruba o turno quando não há mais nada
+      // — nem histórico, nem anexo —; do contrário seguimos com o que existe e as
+      // falhas viram relatório (o usuário não perde a pergunta que já digitou).
+      const idsNovosParaBlocos = [...anexadas, ...anexosNovos];
+      if (!idsNovosParaBlocos.length && !pecasNaConversa.size) {
+        throw new Error(
+          falhasDownload.length === 1
+            ? 'não foi possível baixar "' + falhasDownload[0].titulo + '" — ' + falhasDownload[0].erro
+            : falhasDownload.length
+              ? "nenhuma das " + falhasDownload.length + " peças novas pôde ser baixada"
+              : "não há peça marcada nem arquivo anexado para analisar"
+        );
+      }
+      if (idsNovosParaBlocos.length) {
+        // a guarda conta TUDO que vai no request: peças ativas + todos os anexos
+        // do contexto (não só os novos deste turno — os já enviados seguem no
+        // request pelo histórico).
+        paginas = guardaPaginas([...selectedIds, ...anexos.keys()]);
+        await subirPecas(anexadas);
+        await subirAnexos(anexosNovos);
+        stripOldCacheControl();
+        userContent = [...montarBlocos(idsNovosParaBlocos), { type: "text", text }];
+      } else {
+        // Acompanhamento sem peça/anexo novo (ou todas as novas falharam, mas há
+        // histórico): segue com o contexto já anexado.
+        paginas = guardaPaginas([...selectedIds, ...anexos.keys()]);
         userContent = text;
       }
 
@@ -2707,7 +2825,13 @@
       // um processo vazio, e nada na tela diria isso. As pendentes entram
       // porque o usuário não as desmarcou; desmarcar de verdade continua
       // liberando contexto, porque o id sai do `selPendente` ao ser aplicado.
-      const ativos = new Set(selecaoEfetiva());
+      // Os anexos do input entram SEMPRE em `ativos`: seus blocos carregam
+      // `__pecaId` (o id sintético) para o chip poder liberá-los do contexto
+      // como uma peça desmarcada, mas enquanto estão anexados eles não são
+      // "peça desmarcada" — sem isto `prepararEnvio` os filtraria do histórico já
+      // no segundo turno. Removê-los é ação explícita do usuário (o ✕ do chip
+      // tira o id de `anexos`, e aí este filtro passa a valer para eles também).
+      const ativos = new Set([...selecaoEfetiva(), ...anexos.keys()]);
       // O inventário entra AQUI, na cópia que vai à API — antes do count_tokens,
       // para o pré-voo medir exatamente o request que será enviado.
       const msgsEnvio = comInventario(
@@ -2730,19 +2854,39 @@
       // guarda de 90% e o tratamento de model_context_window_exceeded seguem
       // como rede se a conta estiver errada.
       let est = null;
-      const pulouPreVoo = podePularPreVoo(selectedIds);
+      // Anexo novo é conteúdo que a medição exata anterior não viu: nunca pular o
+      // pré-voo quando há um (o que não foi medido não pode ser dispensado).
+      const pulouPreVoo = !anexosNovos.length && podePularPreVoo(selectedIds);
       if (pulouPreVoo) {
         console.debug("[PJe IA] pré-voo pulado: folga larga sobre a medição exata anterior");
       } else {
         panel.setStatus("Estimando o tamanho do contexto…", true);
         est = await estimarContexto(msgsEnvio, opts);
       }
-      if (attach) panel.endPrep(); // confirma "peças anexadas" após validar limites
+      if (novas.length) panel.endPrep(); // confirma "peças anexadas" após validar limites
       // Relatório do que ficou de fora. Fica NO CHAT (não no .status, que é
       // transitório): o usuário precisa poder ler com calma, ver o motivo de
       // cada peça e tentar de novo depois — sem que a análise que ele pediu
       // tenha sido perdida no caminho.
-      if (falhasDownload.length) panel.mostrarFalhasPecas(falhasDownload);
+      //
+      // E a peça que falhou é TIRADA DA SELEÇÃO (desmarcada): é o que impede o
+      // bug de ela travar o próximo turno. Como ela nunca entrou no histórico,
+      // seguir marcada só a faria ser re-tentada a cada envio — e quando fosse a
+      // única peça "nova", o turno seguinte abortava inteiro, obrigando o usuário
+      // a caçar e desmarcar a peça à mão. Desmarcá-la aqui é fazer por ele o que
+      // ele teria de fazer; o aviso diz que ela saiu e como reanexar (marcar de
+      // novo = nova tentativa de download).
+      if (falhasDownload.length) {
+        panel.mostrarFalhasPecas(falhasDownload, {
+          dica:
+            "Para não travar a conversa, " +
+            (falhasDownload.length === 1 ? "a peça foi retirada" : "as peças foram retiradas") +
+            " da seleção — a análise seguiu com o restante. Para tentar de novo, " +
+            (falhasDownload.length === 1 ? "marque-a" : "marque-as") +
+            " outra vez na lista; se persistir, abra a peça uma vez na linha do tempo do PJe antes.",
+        });
+        panel.desmarcarPecas(falhasDownload.map((f) => f.id));
+      }
       // Peças que a memória retomou mas cujo upload não existe mais no
       // provedor, e que não foram rebaixadas a tempo. Grupo próprio porque a
       // causa e a saída são outras: não é "o PJe não entregou", é "o arquivo
@@ -2768,7 +2912,7 @@
           ctxTokens: est.ctxTokens,
           paginas,
           maxPaginas: modelCaps ? modelCaps.maxPages : 0,
-          pecas: selectedIds.length,
+          pecas: selectedIds.length + anexos.size,
         });
       } else {
         // Dois caminhos chegam aqui: o pré-voo foi PULADO (folga larga) ou ele
@@ -2911,7 +3055,17 @@
         });
         // turno gravado com tools declaradas \u2192 mant\u00EA-las at\u00E9 "Nova conversa"
         if (opts.tools) buscaNaConversa = true;
-        atualizarGaugePosTurno(fim, selectedIds);
+        // Anexos deste turno passaram a fazer parte do hist\u00F3rico: saem da fila de
+        // pendentes (n\u00E3o se reanexam no pr\u00F3ximo envio) e seguem no chip como "no
+        // contexto", igual \u00E0s pe\u00E7as enviadas.
+        if (anexosNovos.length) {
+          for (const id of anexosNovos) {
+            const i = anexosPendentes.indexOf(id);
+            if (i >= 0) anexosPendentes.splice(i, 1);
+          }
+          atualizarChipsAnexos();
+        }
+        atualizarGaugePosTurno(fim, [...selectedIds, ...anexos.keys()]);
         let st = "";
         if (truncated)
           st = "A resposta atingiu o tamanho máximo — peça para continuar, se necessário.";
@@ -2952,6 +3106,27 @@
                 );
               } finally {
                 if (btn) btn.disabled = false;
+              }
+            },
+          });
+        }
+
+        // Peças que a resposta apontou como faltantes viram botões de "adicionar"
+        // — o modelo já identifica "o comprovante está na peça 214661494, não
+        // anexada"; aqui esse id vira um clique que marca a peça para o próximo
+        // envio, sem o usuário ter de procurá-la na lista.
+        const faltantes = pecasCitadasFaltantes(mdResposta);
+        if (faltantes.length) {
+          panel.sugerirPecas(assistantEl, {
+            pecas: faltantes,
+            onAdd: (ids) => {
+              const novos = panel.marcarPecas(ids);
+              if (novos && novos.length) {
+                panel.setStatus(
+                  novos.length === 1
+                    ? "Peça adicionada à seleção — ela entra no próximo envio."
+                    : novos.length + " peças adicionadas à seleção — entram no próximo envio."
+                );
               }
             },
           });
@@ -3013,6 +3188,107 @@
       salvarCasoAgora();
     }
   });
+
+  // ---------------------------------------------------------------------------
+  // ANEXOS DO INPUT — o usuário solta PDF/TXT/MD na caixa de mensagem para
+  // conversar sobre eles junto das peças, ou sozinhos. A UI (botão 📎, campo de
+  // arquivo e os chips) vive no painel; aqui está a leitura, o estado e o que
+  // vai ao modelo. Regras: leitura pelo MESMO extrator das peças
+  // (`PJE.lerAnexo` → `lerCorpo`), nada ao disco (sessão só), e cada anexo entra
+  // no request pelo mesmo `montarBlocos` das peças (id sintético + `entradaDoc`).
+  // ---------------------------------------------------------------------------
+
+  // Rótulo curto para o chip: tipo + tamanho/páginas.
+  function anexoSubLabel(d) {
+    if (!d) return "";
+    if (d.kind === "pdf") return "PDF · " + (d.pages || 1) + (d.pages === 1 ? " pág." : " págs.");
+    if (d.kind === "img") return (d.fmt || "imagem").toUpperCase();
+    const kb = Math.max(1, Math.round((d.size || (d.text ? d.text.length : 0)) / 1024));
+    return (d.fmt === "html" ? "HTML" : "Texto") + " · " + kb + " KB";
+  }
+
+  // Reprojeta os anexos no painel (chips). O painel é só reflexo — a fonte de
+  // verdade é a Map `anexos` daqui.
+  function atualizarChipsAnexos() {
+    if (!panel.setAnexos) return;
+    panel.setAnexos(
+      [...anexos.values()].map((d) => ({
+        id: d.id,
+        nome: d.titulo || d.nome,
+        sub: anexoSubLabel(d),
+        enviado: !anexosPendentes.includes(d.id),
+      }))
+    );
+  }
+
+  // Feedback imediato no medidor ao anexar/remover, incluindo os anexos.
+  function reestimarComAnexos() {
+    if (busy || !modelCaps) return;
+    mostrarEstimativaLocal([...selecaoEfetiva(), ...anexos.keys()]);
+  }
+
+  // Teto de sanidade por anexo (antes do teto de b64 compartilhado que
+  // `montarBlocos` aplica no conjunto todo). PDFs grandes vão à Files API, mas
+  // acima disto o base64 na memória e o pré-voo já ficam pesados demais para uma
+  // caixa de mensagem — o usuário anexa a peça pelo próprio PJe nesse caso.
+  const ANEXO_BYTES_MAX = 32 * 1024 * 1024; // 32 MB por arquivo
+  const ANEXO_MAX_QTD = 10; // por sessão — a caixa de mensagem não é gerenciador de arquivos
+
+  if (panel.onAnexar) {
+    panel.onAnexar(async (files) => {
+      const lista = [...(files || [])];
+      if (!lista.length) return;
+      const falhas = [];
+      let entrou = 0;
+      for (const file of lista) {
+        if (anexos.size >= ANEXO_MAX_QTD) {
+          falhas.push({ titulo: file.name || "arquivo", erro: "limite de " + ANEXO_MAX_QTD + " anexos por conversa atingido" });
+          continue;
+        }
+        if (file.size > ANEXO_BYTES_MAX) {
+          falhas.push({
+            titulo: file.name || "arquivo",
+            erro: "arquivo grande demais (" + Math.round(file.size / 1e6) + " MB) para anexar aqui",
+          });
+          continue;
+        }
+        try {
+          const corpo = await PJE.lerAnexo(file);
+          const id = "anexo:" + ++anexoSeq;
+          const nomeCurto = (file.name || "arquivo").replace(/\.[^.]+$/, "");
+          anexos.set(id, Object.assign({}, corpo, { id, nome: file.name, titulo: "Anexo — " + nomeCurto }));
+          anexosPendentes.push(id);
+          entrou++;
+        } catch (e) {
+          falhas.push({ titulo: file.name || "arquivo", erro: (e && e.message) || String(e) });
+        }
+      }
+      if (entrou) {
+        atualizarChipsAnexos();
+        reestimarComAnexos();
+      }
+      if (falhas.length) {
+        panel.mostrarFalhasPecas(falhas, {
+          titulo: falhas.length === 1 ? "1 arquivo não pôde ser anexado" : falhas.length + " arquivos não puderam ser anexados",
+          dica: "A extensão anexa PDF, TXT e Markdown (.md). Verifique o formato e o tamanho e tente de novo.",
+        });
+      }
+    });
+  }
+
+  if (panel.onRemoverAnexo) {
+    panel.onRemoverAnexo((id) => {
+      if (!anexos.has(id)) return;
+      // Sai da Map (é o que faz `prepararEnvio` filtrar os blocos dele do
+      // histórico no próximo envio, liberando o contexto — simétrico ao
+      // desmarcar de uma peça) e da fila de pendentes.
+      anexos.delete(id);
+      const i = anexosPendentes.indexOf(id);
+      if (i >= 0) anexosPendentes.splice(i, 1);
+      atualizarChipsAnexos();
+      reestimarComAnexos();
+    });
+  }
 
   // ---------------------------------------------------------------------------
   // ESCOLHER COM IA — a camada 2 da seleção de peças.
@@ -3939,6 +4215,10 @@
   function zerarEstadoDaConversa() {
     conversation = [];
     pecasNaConversa.clear();
+    // Anexos são da CONVERSA, não do processo: "Nova conversa" os solta (ao
+    // contrário das peças, que servem a todas as conversas do processo).
+    anexos.clear();
+    anexosPendentes.length = 0;
     custoConversaUsd = 0;
     conversaProvider = null;
     buscaNaConversa = false;
@@ -3949,6 +4229,7 @@
     panel.setContexto(null);
     panel.setAlerta(null);
     panel.setPecasEnviadas([]);
+    if (panel.setAnexos) panel.setAnexos([]);
   }
 
   panel.onTrocarConversa((convId) => {
@@ -4020,6 +4301,21 @@
     // API, e `conversation = undefined` derrubaria o próximo `.length` — que é
     // lido em quase todo caminho do envio.
     conversation = Array.isArray(caso.conversation) ? caso.conversation : [];
+    // Anexos do input são de SESSÃO: seus bytes não vão ao disco, então numa
+    // conversa retomada os blocos deles apontariam para uploads que não voltam
+    // (e o base64, se fosse o caso, nem foi guardado). Tira-os do histórico aqui
+    // — senão o `file_id` morto daria 400 no primeiro envio — e avisa, para o
+    // usuário saber que pode reanexá-los. Peças do PJe continuam intactas: elas
+    // se re-baixam e `revalidarPecasDoHistorico` cuida dos uploads vencidos.
+    let anexosRetomados = 0;
+    for (const turno of conversation) {
+      if (!Array.isArray(turno.content)) continue;
+      const antes = turno.content.length;
+      turno.content = turno.content.filter(
+        (b) => !(b && typeof b.__pecaId === "string" && b.__pecaId.indexOf("anexo:") === 0)
+      );
+      anexosRetomados += antes - turno.content.length;
+    }
     pecasNaConversa = new Set(caso.pecasNaConversa || []);
     custoConversaUsd = caso.custoConversaUsd || 0;
     conversaProvider = caso.conversaProvider || null;
@@ -4038,6 +4334,12 @@
       // Só o acumulado da conversa: não houve turno nesta sessão, e mostrar um
       // "nesta resposta" seria afirmar um custo que não aconteceu agora.
       panel.setCusto({ conversaUsd: custoConversaUsd });
+    }
+    if (anexosRetomados) {
+      panel.setStatus(
+        "Os arquivos anexados nesta conversa não são guardados entre sessões — " +
+          "anexe-os de novo (📎) se precisar retomá-los."
+      );
     }
     // ABRIU. Sem este `true` a conversa aparece na tela mas o chamador não
     // assume a identidade dela — e a gravação seguinte cria uma DUPLICATA em

--- a/src/content.js
+++ b/src/content.js
@@ -4307,13 +4307,16 @@
     // — senão o `file_id` morto daria 400 no primeiro envio — e avisa, para o
     // usuário saber que pode reanexá-los. Peças do PJe continuam intactas: elas
     // se re-baixam e `revalidarPecasDoHistorico` cuida dos uploads vencidos.
+    const ehBlocoAnexo = (b) =>
+      b && typeof b.__pecaId === "string" && b.__pecaId.indexOf("anexo:") === 0;
     let anexosRetomados = 0;
     for (const turno of conversation) {
       if (!Array.isArray(turno.content)) continue;
+      // só reescreve o content quando há mesmo um bloco de anexo — uma conversa
+      // normal (o caso comum) não é tocada.
+      if (!turno.content.some(ehBlocoAnexo)) continue;
       const antes = turno.content.length;
-      turno.content = turno.content.filter(
-        (b) => !(b && typeof b.__pecaId === "string" && b.__pecaId.indexOf("anexo:") === 0)
-      );
+      turno.content = turno.content.filter((b) => !ehBlocoAnexo(b));
       anexosRetomados += antes - turno.content.length;
     }
     pecasNaConversa = new Set(caso.pecasNaConversa || []);

--- a/src/docx-importar.js
+++ b/src/docx-importar.js
@@ -113,16 +113,101 @@ const DocxImport = (() => {
       .trim();
   }
 
+  // -------------------------------------------------------------------------
+  // Extrator de RTF (editor antigo do PJe, comum em processos migrados). É uma
+  // CÓPIA da lógica de `rtfParaTexto` do `pje.js`: a importação de modelos roda
+  // também na página `src/modelos.html`, um contexto de extensão que NÃO enxerga
+  // o global `PJE` (content script) — a mesma razão de o `mapa.js` duplicar
+  // `escapeHtml`/`inlineMd`. RTF é ASCII com grupos entre chaves e control words
+  // (`\par`, `\'e7`…); extraímos só o TEXTO. `file.text()` decodifica em UTF-8,
+  // o que basta: o RTF bem-formado escapa os bytes altos como `\'XX`.
+  const CP1252_ALTO = {
+    128: "€", 130: "‚", 131: "ƒ", 132: "„", 133: "…", 134: "†", 135: "‡",
+    136: "ˆ", 137: "‰", 138: "Š", 139: "‹", 140: "Œ", 142: "Ž", 145: "‘",
+    146: "’", 147: "“", 148: "”", 149: "•", 150: "–", 151: "—", 152: "˜",
+    153: "™", 154: "š", 155: "›", 156: "œ", 158: "ž", 159: "Ÿ",
+  };
+  const RTF_GRUPOS_MORTOS =
+    /^\\(?:\*|(?:fonttbl|colortbl|stylesheet|info|pntext|listtable|listoverridetable|rsidtbl|generator|themedata|datastore|xmlnstbl|latentstyles)\b)/;
+
+  function rtfParaTexto(rtf) {
+    const s = String(rtf || "");
+    let out = "";
+    let i = 0;
+    let pularUnicode = 0; // \ucN — quantos caracteres de fallback ignorar
+    while (i < s.length) {
+      const c = s[i];
+      if (c === "{") {
+        const resto = s.slice(i + 1, i + 40);
+        if (RTF_GRUPOS_MORTOS.test(resto)) {
+          let nivel = 0;
+          while (i < s.length) {
+            if (s[i] === "\\" && (s[i + 1] === "{" || s[i + 1] === "}")) { i += 2; continue; }
+            if (s[i] === "{") nivel++;
+            else if (s[i] === "}") {
+              nivel--;
+              if (nivel === 0) { i++; break; }
+            }
+            i++;
+          }
+          continue;
+        }
+        i++;
+        continue;
+      }
+      if (c === "}") { i++; continue; }
+      if (c === "\\") {
+        const n = s[i + 1];
+        if (n === "\\" || n === "{" || n === "}") { out += n; i += 2; continue; }
+        if (n === "\n" || n === "\r") { out += "\n"; i += 2; continue; }
+        if (n === "'") {
+          const code = parseInt(s.substr(i + 2, 2), 16);
+          if (!isNaN(code)) {
+            if (pularUnicode > 0) pularUnicode--;
+            else out += CP1252_ALTO[code] || String.fromCharCode(code);
+          }
+          i += 4;
+          continue;
+        }
+        const m = /^\\([a-zA-Z]+)(-?\d+)?[ ]?/.exec(s.slice(i));
+        if (!m) { i += 2; continue; }
+        const palavra = m[1];
+        const arg = m[2] != null ? parseInt(m[2], 10) : null;
+        if (palavra === "par" || palavra === "line" || palavra === "sect") out += "\n";
+        else if (palavra === "tab") out += "\t";
+        else if (palavra === "uc") pularUnicode = 0;
+        else if (palavra === "u" && arg != null) {
+          out += String.fromCharCode(arg < 0 ? arg + 65536 : arg);
+          pularUnicode = 1;
+        }
+        i += m[0].length;
+        continue;
+      }
+      if (c === "\r" || c === "\n") { i++; continue; }
+      if (pularUnicode > 0) { pularUnicode--; i++; continue; }
+      out += c;
+      i++;
+    }
+    return out.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
+  }
+
   // API: recebe um File (do <input type="file">) e devolve o texto.
   async function lerArquivo(file) {
     if (!file) throw new Error("nenhum arquivo escolhido");
     const nome = String(file.name || "").toLowerCase();
+    // RTF: editor antigo, comum em processos migrados. Lido pelo extrator próprio
+    // acima — nada de ZIP/DecompressionStream (RTF não é compactado).
+    if (nome.endsWith(".rtf")) {
+      const texto = rtfParaTexto(await file.text());
+      if (!texto) throw new Error("o documento .rtf está vazio ou não tem texto legível");
+      return texto;
+    }
     if (nome.endsWith(".doc") && !nome.endsWith(".docx")) {
       throw new Error(
-        "o formato .doc (Word 97-2003) não pode ser lido aqui — abra no Word e salve como .docx"
+        "o formato .doc (Word 97-2003) não pode ser lido aqui — abra no Word e salve como .docx ou .rtf"
       );
     }
-    if (!nome.endsWith(".docx")) throw new Error("escolha um arquivo .docx");
+    if (!nome.endsWith(".docx")) throw new Error("escolha um arquivo .docx ou .rtf");
     if (typeof DecompressionStream === "undefined") {
       throw new Error("este navegador não sabe descompactar .docx — atualize o Chrome");
     }
@@ -139,7 +224,7 @@ const DocxImport = (() => {
   // Título sugerido a partir do nome do arquivo (sem extensão, com espaços).
   function tituloDe(file) {
     return String((file && file.name) || "")
-      .replace(/\.docx$/i, "")
+      .replace(/\.(docx|rtf)$/i, "")
       .replace(/[_-]+/g, " ")
       .replace(/\s+/g, " ")
       .trim()
@@ -192,5 +277,5 @@ const DocxImport = (() => {
     return saida;
   }
 
-  return { lerArquivo, lerLote, tituloDe, _textoDoXml: textoDoXml };
+  return { lerArquivo, lerLote, tituloDe, _textoDoXml: textoDoXml, _rtfParaTexto: rtfParaTexto };
 })();

--- a/src/gemini.js
+++ b/src/gemini.js
@@ -255,14 +255,21 @@ export async function* streamGemini(req) {
   let resp = await enviar(safetyGeminiSuportado);
   if (!resp.ok) {
     let apiMsg = await lerCorpoErroGemini(resp);
-    // AUTOCURA do safety_settings: só se o erro NOMEIA o campo. Um bloqueio de
-    // política comum ("unspecified policy reason") não cita `safety_settings`,
-    // então NÃO dispara um segundo envio dos autos (caro) à toa.
-    if (
-      resp.status === 400 &&
-      safetyGeminiSuportado &&
-      apiMsg.toLowerCase().includes("safety_settings")
-    ) {
+    // AUTOCURA do safety_settings: só quando o erro fala do CAMPO. Um bloqueio
+    // de política comum ("blocked for an unspecified policy reason") não fala,
+    // então não dispara um segundo envio dos autos (caro) à toa.
+    //
+    // O casamento é por `/safety/`, e não pelo literal `safety_settings`, porque
+    // a API recusa o campo em pelo menos TRÊS redações e só a primeira traz o
+    // nome em snake_case: campo desconhecido ("Unknown name \"safety_settings\""),
+    // valor de enum inválido ("Unknown value at 'safety_settings[4].category'" —
+    // o caso real de `HARM_CATEGORY_CIVIC_INTEGRITY`, que nem toda versão
+    // conhece) e threshold restrito ("Safety setting threshold ... restricted",
+    // com espaço e maiúscula). Errar aqui não custa um recurso: o Gemini é o
+    // provedor PADRÃO, então um 400 não reconhecido deixa a extensão sem
+    // responder nada na primeira pergunta de quem acabou de instalar. O preço do
+    // casamento largo é, no pior caso, UM reenvio por vida do worker.
+    if (resp.status === 400 && safetyGeminiSuportado && /safety/i.test(apiMsg)) {
       safetyGeminiSuportado = false;
       console.debug("[PJe IA] Gemini: safety_settings não aceito — reenviando sem o campo e desativando nesta sessão");
       resp = await enviar(false);

--- a/src/gemini.js
+++ b/src/gemini.js
@@ -697,6 +697,25 @@ export async function friendlyHttpErrorGemini(resp) {
   ) {
     return "As peças selecionadas excedem o contexto do modelo. Desmarque algumas peças ou inicie uma nova conversa.";
   }
+  // Filtro de CONTEÚDO do Google (não é erro da extensão nem das peças): autos
+  // descrevem violência, crimes, drogas etc. e o Gemini barra na borda, ANTES de
+  // o modelo ver. É determinístico pelo conteúdo — por isso não é re-tentável
+  // (o chamador não repete) — e a camada de "unspecified policy" costuma ser a
+  // NÃO-configurável (safety_settings não a afrouxam). A saída prática é trocar
+  // de provedor ou reduzir/isolar a peça que dispara o filtro.
+  if (
+    resp.status === 400 &&
+    (low.includes("policy") ||
+      low.includes("prohibited") ||
+      (low.includes("blocked") && low.includes("modify your input")))
+  ) {
+    return (
+      "O Google bloqueou esta análise no filtro de conteúdo dele — as peças descrevem " +
+      "fatos que a política do Gemini barra. Não é falha da extensão. Para seguir: use " +
+      "um modelo Claude (Anthropic) nesta análise (ele não aplica esse bloqueio a " +
+      "conteúdo jurídico), ou envie menos peças por vez para descobrir qual dispara o filtro."
+    );
+  }
   if (resp.status === 429) {
     return (
       "Limite de requisições da API do Google atingido (no plano gratuito a cota é pequena). " +

--- a/src/gemini.js
+++ b/src/gemini.js
@@ -172,79 +172,109 @@ function traduzirHistorico(messages) {
 // no request para a resposta nunca ser cortada por um default menor.
 const MAX_OUTPUT_TOKENS = 65536;
 
+// "Deixar livre": afrouxa ao MÁXIMO o filtro de conteúdo CONFIGURÁVEL do Gemini.
+// Autos descrevem violência, crimes, drogas, abuso — conteúdo jurídico legítimo
+// que o filtro barra por padrão. BLOCK_NONE em todas as categorias é o mais
+// permissivo aceito de forma universal (o threshold "OFF" não existe em todos os
+// modelos). ATENÇÃO: isto NÃO afeta a camada NÃO-configurável do Google (o "400
+// blocked for an unspecified policy reason") — essa não há como desligar; para
+// conteúdo barrado ali, a saída segue sendo trocar para um modelo Claude.
+const SAFETY_LIVRE = [
+  { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_NONE" },
+  { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_NONE" },
+  { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold: "BLOCK_NONE" },
+  { category: "HARM_CATEGORY_DANGEROUS_CONTENT", threshold: "BLOCK_NONE" },
+  { category: "HARM_CATEGORY_CIVIC_INTEGRITY", threshold: "BLOCK_NONE" },
+];
+// AUTOCURA: se a Interactions API não aceitar `safety_settings` (400 nomeando o
+// campo), reenviamos SEM ele e desligamos isto para a sessão — o provedor PADRÃO
+// (Gemini) nunca pode quebrar por causa de um campo que a versão da API não
+// conhece. Volta a `true` quando o worker reinicia (re-aprende).
+let safetyGeminiSuportado = true;
+
 // req: {apiKey, model, system, messages, tools?, thinkingLevel?}
 // Campos do caminho Anthropic (betas, container, thinking, output_config,
 // max_tokens) são simplesmente ignorados — em especial max_tokens (32000):
 // aqui o teto é MAX_OUTPUT_TOKENS (ver o cabeçalho do arquivo).
 export async function* streamGemini(req) {
-  const body = {
-    model: req.model,
-    system_instruction: req.system,
-    input: traduzirHistorico(req.messages),
-    store: false,
-    stream: true,
-    generation_config: { max_output_tokens: MAX_OUTPUT_TOKENS },
-  };
-  if (req.tools && req.tools.length) body.tools = req.tools;
-  if (req.thinkingLevel) {
-    body.generation_config.thinking_level = req.thinkingLevel;
+  // Histórico traduzido UMA vez — reusado se precisar re-montar o corpo sem
+  // safety_settings no fallback de autocura abaixo.
+  const input = traduzirHistorico(req.messages);
+  const generation_config = { max_output_tokens: MAX_OUTPUT_TOKENS };
+  if (req.thinkingLevel) generation_config.thinking_level = req.thinkingLevel;
+
+  // Monta e SERIALIZA o corpo (uma vez por chamada — `JSON.stringify` duas vezes
+  // custa caro no fallback base64, com peça inline de dezenas de MB). `incluiSafety`
+  // liga o afrouxamento do filtro configurável (ver SAFETY_LIVRE).
+  function prepararCorpo(incluiSafety) {
+    const body = {
+      model: req.model,
+      system_instruction: req.system,
+      input,
+      store: false,
+      stream: true,
+      generation_config,
+    };
+    if (req.tools && req.tools.length) body.tools = req.tools;
+    if (incluiSafety) body.safety_settings = SAFETY_LIVRE;
+    let corpoJson;
+    try {
+      corpoJson = JSON.stringify(body);
+    } catch (e) {
+      console.error("[PJe IA] Gemini: request não serializável:", e);
+      throw new Error("Falha ao montar o request para a API do Google.");
+    }
+    // Radiografia da FORMA no console do service worker (só tipos e KB; nenhum
+    // conteúdo de peça é impresso — NÃO despejar o body: carrega trecho dos autos).
+    try {
+      console.log(
+        "[PJe IA] Gemini request: " +
+          (corpoJson.length / 1024).toFixed(0) + " KB | itens: " +
+          (body.input || [])
+            .map((it) => {
+              if (it.type === "user_input" || it.type === "model_output") {
+                return it.type + "(" + (it.content || []).map((c) => c.type).join("+") + ")";
+              }
+              return it.type + (it.signature ? "[sig]" : "");
+            })
+            .join(" > ")
+      );
+    } catch {
+      /* console indisponível */
+    }
+    return corpoJson;
   }
 
-  // Serializa UMA vez: o mesmo texto vai no fetch e alimenta o tamanho no log.
-  // Fazer `JSON.stringify(body)` duas vezes por request custava caro de verdade
-  // no caminho de fallback base64 (uma peça inline pode ter dezenas de MB, e o
-  // service worker paga isso em memória e em latência antes do primeiro token).
-  let corpoJson;
-  try {
-    corpoJson = JSON.stringify(body);
-  } catch (e) {
-    // Corpo não serializável: isso por si só explicaria um request malformado,
-    // e o fetch falharia adiante com um erro que não diz nada.
-    console.error("[PJe IA] Gemini: request não serializável:", e);
-    throw new Error("Falha ao montar o request para a API do Google.");
-  }
+  const enviar = (incluiSafety) =>
+    fetch(API + "/interactions", {
+      method: "POST",
+      headers: headersGemini(req.apiKey),
+      body: prepararCorpo(incluiSafety),
+    });
 
-  // Radiografia da FORMA do request no console do service worker (F12 em
-  // chrome://extensions → "service worker"). Um 400 de corpo vazio é rejeição
-  // na BORDA — request malformado —, e o que resolveu o último caso foi
-  // comparar a forma do turno que passa com a do que falha. Só tipos e
-  // tamanho: nenhum conteúdo de peça é impresso.
-  try {
-    console.log(
-      "[PJe IA] Gemini request: " +
-        (corpoJson.length / 1024).toFixed(0) + " KB | itens: " +
-        (body.input || [])
-          .map((it) => {
-            if (it.type === "user_input" || it.type === "model_output") {
-              return it.type + "(" + (it.content || []).map((c) => c.type).join("+") + ")";
-            }
-            // steps opacos: mostra também se carregam assinatura
-            return it.type + (it.signature ? "[sig]" : "");
-          })
-          .join(" > ")
-    );
-  } catch {
-    /* console indisponível */
-  }
-
-  const resp = await fetch(API + "/interactions", {
-    method: "POST",
-    headers: headersGemini(req.apiKey),
-    body: corpoJson,
-  });
+  let resp = await enviar(safetyGeminiSuportado);
   if (!resp.ok) {
-    // NÃO logar o `body` aqui. Durante o diagnóstico do 400 do 2º turno ele foi
-    // despejado inteiro no console para poder ser reproduzido byte a byte — o
-    // que era certo naquele momento e é errado num pacote publicado: o objeto
-    // carrega trecho dos autos (e o base64 das peças que não subiram à Files
-    // API) e fica retido em memória enquanto o DevTools estiver aberto. A linha
-    // de forma acima já situa o request; se um caso novo exigir o corpo, este
-    // log volta temporariamente, em desenvolvimento.
-    const err = new Error(await friendlyHttpErrorGemini(resp));
-    err.status = resp.status;
-    // transitórios: o chamador re-tenta o MESMO request com backoff
-    err.retryable = resp.status === 429 || resp.status >= 500;
-    throw err;
+    let apiMsg = await lerCorpoErroGemini(resp);
+    // AUTOCURA do safety_settings: só se o erro NOMEIA o campo. Um bloqueio de
+    // política comum ("unspecified policy reason") não cita `safety_settings`,
+    // então NÃO dispara um segundo envio dos autos (caro) à toa.
+    if (
+      resp.status === 400 &&
+      safetyGeminiSuportado &&
+      apiMsg.toLowerCase().includes("safety_settings")
+    ) {
+      safetyGeminiSuportado = false;
+      console.debug("[PJe IA] Gemini: safety_settings não aceito — reenviando sem o campo e desativando nesta sessão");
+      resp = await enviar(false);
+      if (!resp.ok) apiMsg = await lerCorpoErroGemini(resp);
+    }
+    if (!resp.ok) {
+      const err = new Error(mensagemErroGemini(resp.status, apiMsg));
+      err.status = resp.status;
+      // transitórios: o chamador re-tenta o MESMO request com backoff
+      err.retryable = resp.status === 429 || resp.status >= 500;
+      throw err;
+    }
   }
 
   // Acumula os STEPS do turno (indexados por ev.index). interaction.completed
@@ -641,15 +671,14 @@ function textoDeStep(s) {
   }
 }
 
-// Converte respostas de erro da API do Google em mensagens claras em português.
-export async function friendlyHttpErrorGemini(resp) {
+// Lê o corpo de erro de uma Response do Google UMA vez (o corpo de uma Response
+// só pode ser consumido uma vez — `resp.json()` + `resp.text()` no catch lança
+// "body stream already read") e devolve a mensagem da API. Também loga
+// status/URL: a única pista de QUAL endpoint recusou (stream /interactions vs.
+// pré-voo :countTokens). Separado de `mensagemErroGemini` para o stream poder
+// INSPECIONAR o corpo (detectar a rejeição de `safety_settings`) sem reler.
+export async function lerCorpoErroGemini(resp) {
   let apiMsg = "";
-  // O corpo é lido como TEXTO uma única vez e só depois interpretado. Ler com
-  // `resp.json()` e cair para `resp.text()` no catch não funciona: o corpo de
-  // uma Response só pode ser consumido UMA vez, então o `text()` do fallback
-  // lançaria "body stream already read" e o erro não-JSON (HTML de proxy, corpo
-  // vazio) — justamente o caso que o fallback existia para cobrir — chegaria ao
-  // usuário como "Erro da API do Google (400)", sem pista nenhuma.
   let bruto = "";
   try {
     bruto = await resp.text();
@@ -660,8 +689,7 @@ export async function friendlyHttpErrorGemini(resp) {
     const j = bruto ? JSON.parse(bruto) : null;
     // A API do Google devolve o erro em DUAS formas: o objeto {error:{message}}
     // e, em alguns endpoints, um ARRAY [{error:{message}}]. Sem tratar o array,
-    // `apiMsg` ficava vazio e o usuário via só "Erro da API do Google (400)" —
-    // uma mensagem que não diz nada e transforma o diagnóstico em adivinhação.
+    // `apiMsg` ficava vazio e o usuário via só "Erro da API do Google (400)".
     const raiz = Array.isArray(j) ? j.find((x) => x && x.error) || {} : j || {};
     apiMsg = (raiz.error && (raiz.error.message || raiz.error.status)) || "";
     // Último recurso: corpo JSON com forma inesperada. Melhor mostrar um trecho
@@ -671,11 +699,6 @@ export async function friendlyHttpErrorGemini(resp) {
     // corpo não-JSON: ainda assim pode ter texto útil (HTML de proxy, etc.)
     apiMsg = bruto.slice(0, 240);
   }
-  // O erro é CAPTURADO e vira texto para o usuário — sem este log ele nunca
-  // aparece no console do service worker, e um 400 de corpo vazio (rejeição no
-  // edge, antes de chegar ao modelo) fica indistinguível de um erro do modelo.
-  // A URL e o status são a única pista de QUAL endpoint recusou: o stream
-  // (/interactions) e o pré-voo (:countTokens) usam este mesmo handler.
   try {
     console.error(
       "[PJe IA] Gemini HTTP " + resp.status + " em " + resp.url + " — corpo: " + (apiMsg || "(vazio)")
@@ -683,7 +706,13 @@ export async function friendlyHttpErrorGemini(resp) {
   } catch {
     /* console indisponível */
   }
-  const low = apiMsg.toLowerCase();
+  return apiMsg;
+}
+
+// Converte status + corpo (já lido) em mensagem clara em português.
+function mensagemErroGemini(status, apiMsg) {
+  const resp = { status }; // as ramificações abaixo comparam resp.status
+  const low = (apiMsg || "").toLowerCase();
 
   if (resp.status === 400 && (low.includes("api key not valid") || low.includes("api_key_invalid"))) {
     return "Chave da API do Google inválida. Confira a chave Gemini nas configurações da extensão.";
@@ -729,4 +758,10 @@ export async function friendlyHttpErrorGemini(resp) {
     return "A API do Google está sobrecarregada no momento. Tente novamente em instantes.";
   }
   return "Erro da API do Google (" + resp.status + ")" + (apiMsg ? ": " + apiMsg.slice(0, 240) : "");
+}
+
+// Assinatura preservada para os call sites (upload/countTokens): lê o corpo e
+// monta a mensagem num passo só.
+export async function friendlyHttpErrorGemini(resp) {
+  return mensagemErroGemini(resp.status, await lerCorpoErroGemini(resp));
 }

--- a/src/modelos-page.js
+++ b/src/modelos-page.js
@@ -98,7 +98,7 @@
       '<div class="vd">Cadastre as suas peças-modelo — sentenças, decisões, despachos, ' +
       "ofícios — e, ao gerar uma minuta, o assistente segue a <b>estrutura</b> e o estilo " +
       "delas. Os fatos continuam saindo apenas das peças do processo em tela.<br><br>" +
-      "Se você já tem essas peças no Word, <b>Importar .docx</b> lê várias de uma vez " +
+      "Se você já tem essas peças no Word (.docx) ou em RTF, <b>Importar</b> lê várias de uma vez " +
       "e deixa tudo preenchido para você conferir.</div>" +
       "</div>"
     );
@@ -441,7 +441,7 @@
     elDrop.classList.toggle("compacta", conferindo);
     elDrop.querySelector(".imp-drop-t").innerHTML = conferindo
       ? "Arraste ou clique para <b>adicionar mais</b> arquivos"
-      : "Arraste seus arquivos <b>.docx</b> até aqui";
+      : "Arraste seus arquivos <b>.docx</b> ou <b>.rtf</b> até aqui";
     elProg.hidden = qual !== "lendo";
     elFichas.hidden = qual === "resultado";
     // O rodapé aparece também no VAZIO, com só o "Voltar": sem ele, quem abriu

--- a/src/modelos.html
+++ b/src/modelos.html
@@ -15,7 +15,7 @@
         <span class="s">guardados neste computador · usados ao gerar minutas</span>
       </div>
       <div class="acoes">
-        <button id="importarLote"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20V9"/><path d="M7 13l5-5 5 5"/><path d="M5 4h14"/></svg><span>Importar .docx</span></button>
+        <button id="importarLote"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20V9"/><path d="M7 13l5-5 5 5"/><path d="M5 4h14"/></svg><span>Importar .docx/.rtf</span></button>
         <button id="novo" class="primario"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14"/><path d="M5 12h14"/></svg><span>Novo modelo</span></button>
       </div>
     </header>
@@ -74,15 +74,15 @@
           <label class="campo">
             <span class="rot">
               Texto da peça-modelo
-              <button type="button" id="importar" class="mini"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20V9"/><path d="M7 13l5-5 5 5"/><path d="M5 4h14"/></svg><span>Importar de .docx</span></button>
+              <button type="button" id="importar" class="mini"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20V9"/><path d="M7 13l5-5 5 5"/><path d="M5 4h14"/></svg><span>Importar de .docx/.rtf</span></button>
             </span>
             <textarea
               id="fTexto"
-              placeholder="Cole aqui a peça inteira, do cabeçalho ao dispositivo — ou importe um .docx que você já tenha."
+              placeholder="Cole aqui a peça inteira, do cabeçalho ao dispositivo — ou importe um .docx/.rtf que você já tenha."
             ></textarea>
             <span class="dica" id="contChars"></span>
           </label>
-          <input type="file" id="arquivo" accept=".docx" hidden />
+          <input type="file" id="arquivo" accept=".docx,.rtf" hidden />
 
           <div class="erro" id="formErro" role="alert" hidden></div>
 
@@ -96,7 +96,7 @@
       <!-- IMPORTAÇÃO EM LOTE -->
       <section id="telaImportar" class="col" hidden>
         <div class="form-card">
-          <h2 class="serif">Importar modelos de arquivos .docx</h2>
+          <h2 class="serif">Importar modelos de arquivos .docx ou .rtf</h2>
           <p class="form-sub">
             Escolha <b>vários de uma vez</b>. O título e a espécie vêm preenchidos e você
             confere tudo antes de cadastrar. Os arquivos são lidos <b>aqui no seu
@@ -105,9 +105,9 @@
 
           <!-- estado VAZIO -->
           <div class="imp-drop" id="impDrop" role="button" tabindex="0"
-               aria-label="Escolher arquivos .docx — ou arraste os arquivos até aqui">
+               aria-label="Escolher arquivos .docx ou .rtf — ou arraste os arquivos até aqui">
             <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20V9"/><path d="M7 13l5-5 5 5"/><path d="M5 4h14"/></svg>
-            <span class="imp-drop-t">Arraste seus arquivos <b>.docx</b> até aqui</span>
+            <span class="imp-drop-t">Arraste seus arquivos <b>.docx</b> ou <b>.rtf</b> até aqui</span>
             <span class="imp-drop-s">ou clique para escolher — pode mandar 5, 10, quantos quiser</span>
           </div>
 
@@ -136,7 +136,7 @@
             <button type="button" class="primario" id="impFechar">Voltar aos modelos</button>
           </div>
         </div>
-        <input type="file" id="arquivos" accept=".docx" multiple hidden />
+        <input type="file" id="arquivos" accept=".docx,.rtf" multiple hidden />
       </section>
     </main>
 

--- a/src/modelos.js
+++ b/src/modelos.js
@@ -162,7 +162,7 @@ const MLIB = (() => {
 
   function doNome(nomeArquivo) {
     const s = norm(nomeArquivo)
-      .replace(/\.docx$/, "")
+      .replace(/\.(docx|rtf)$/, "")
       .replace(/[_\-.]+/g, " ");
     let melhor = null;
     for (const [cat, re] of RE_NOME) {

--- a/src/openai.js
+++ b/src/openai.js
@@ -264,8 +264,15 @@ export async function* streamOpenAI(req) {
   // completa. Erro re-tentável: o executarTurno re-tenta o mesmo request (o
   // prefixo está no cache automático da OpenAI, custa pouco).
   if (!respostaFinal) {
+    // O SSE terminou sem `response.completed/incomplete` — a conexão caiu no
+    // meio. Continua re-tentável (o worker repete 2×); esta mensagem só chega ao
+    // usuário DEPOIS de as tentativas se esgotarem, então aponta o próximo passo
+    // real: com muitas peças o request fica grande e a queda se repete, logo
+    // reduzir o conjunto costuma ser o que resolve — não só "tentar de novo".
     const err = new Error(
-      "o stream da API da OpenAI terminou sem o evento de conclusão — tente de novo"
+      "a conexão com a OpenAI caiu antes de a resposta terminar. Se persistir, costuma " +
+        "ser o tamanho do envio: reduza as peças selecionadas (use os degraus “chave”/" +
+        "“principais” ou o ✨ Escolher com IA) e tente de novo."
     );
     err.retryable = true;
     throw err;

--- a/src/panel.css
+++ b/src/panel.css
@@ -1541,6 +1541,41 @@ button > svg { flex: none; }
 }
 .pchip:hover .pchip-tip { display: block; }
 
+/* Faixa dos anexos do input (📎), emendada no topo da .inrow como a .promptbar.
+   Diferente dela, pode ter VÁRIOS chips e por isso quebra em linhas. */
+.anexosbar {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  background: var(--hover-2); border: 1px solid var(--line); border-bottom: none;
+  border-radius: 12px 12px 0 0; padding: 6px 9px; margin-bottom: -1px;
+  animation: chip-in 0.18s ease-out;
+}
+.inrow.com-anexo { border-top-left-radius: 0; border-top-right-radius: 0; }
+.achip {
+  display: inline-flex; align-items: center; gap: 6px; max-width: 100%;
+  background: #fff; border: 1px solid var(--line); color: var(--text-3);
+  border-radius: var(--r-pill); padding: 3px 4px 3px 8px; font-size: var(--fs-micro);
+}
+.achip-i { display: inline-flex; color: var(--pje); flex: none; }
+.achip-t {
+  display: inline-flex; align-items: baseline; gap: 6px;
+  min-width: 0; overflow: hidden;
+}
+.achip-t b { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 220px; }
+.achip-s { color: var(--muted); flex: none; }
+.achip.enviado { border-color: var(--pje-soft); background: var(--hover); }
+.achip.enviado .achip-i { color: var(--pje-2); }
+
+/* Botão de anexar dentro da .inrow: ícone discreto à esquerda do textarea. */
+.attach {
+  flex: none; width: 32px; height: 32px; padding: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: transparent; border: none; border-radius: var(--r-ctrl);
+  color: var(--muted-3); cursor: pointer;
+  transition: background 0.14s ease, color 0.14s ease;
+}
+.attach:hover { background: var(--hover); color: var(--pje); }
+.attach:disabled { opacity: 0.5; cursor: default; }
+
 .inrow {
   display: flex; gap: 8px; align-items: flex-end;
   border: 1px solid var(--line); border-radius: 12px; padding: 6px 6px 6px 10px;
@@ -1918,6 +1953,35 @@ button > svg { flex: none; }
   border-style: solid; border-color: var(--pje); color: var(--pje-2);
   background: transparent; filter: none;
 }
+
+/* Peças que a resposta apontou como faltantes → botões de "adicionar ao
+   contexto". Fica FORA do .body (irmã dele) para sobreviver ao updateAssistant,
+   como o .editor-act. */
+.pecas-sug { margin-top: 8px; }
+.pecas-sug-lab { font-size: var(--fs-micro); color: var(--muted); margin-bottom: 5px; }
+.pecas-sug-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.pecas-sug-add {
+  display: inline-flex; align-items: center; gap: 5px; max-width: 100%;
+  border: 1px dashed var(--line); background: transparent; color: var(--text-3);
+  border-radius: var(--r-pill); padding: 4px 10px 4px 8px; font-size: var(--fs-micro);
+  cursor: pointer; transition: all 0.15s;
+}
+.pecas-sug-add:hover { border-style: solid; border-color: var(--pje); color: var(--pje-2); }
+.pecas-sug-add svg { flex: none; color: var(--pje); }
+.pecas-sug-add .ps-id { font-weight: 600; font-variant-numeric: tabular-nums; }
+.pecas-sug-add .ps-t { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 220px; color: var(--muted); }
+.pecas-sug-add.feito {
+  border-style: solid; border-color: var(--ok-line); color: var(--ok-ink);
+  background: var(--ok-bg); cursor: default;
+}
+.pecas-sug-add.feito svg { color: var(--ok); }
+.pecas-sug-all {
+  border: none; background: transparent; color: var(--pje-2);
+  font-size: var(--fs-micro); font-weight: 600; cursor: pointer; padding: 4px 8px;
+  border-radius: var(--r-pill);
+}
+.pecas-sug-all:hover:not(:disabled) { background: var(--hover); }
+.pecas-sug-all:disabled { opacity: 0.5; cursor: default; }
 
 /* ---------- Gerenciador de prompts salvos (modal no Shadow DOM) ---------- */
 .plib {

--- a/src/panel.js
+++ b/src/panel.js
@@ -756,8 +756,8 @@ var PjePanel = (function () {
               <div class="promptbar" hidden></div>
               <div class="anexosbar" hidden></div>
               <div class="inrow">
-                <button class="attach" title="Anexar arquivos (PDF, Word .docx, TXT ou Markdown) para analisar junto das peças — ou sozinhos" aria-label="Anexar arquivos">${SVG.clip}</button>
-                <input type="file" class="attach-input" accept=".pdf,.docx,.txt,.md,.markdown,text/plain,text/markdown,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document" multiple hidden aria-hidden="true">
+                <button class="attach" title="Anexar arquivos (PDF, Word .docx, RTF, TXT ou Markdown) para analisar junto das peças — ou sozinhos" aria-label="Anexar arquivos">${SVG.clip}</button>
+                <input type="file" class="attach-input" accept=".pdf,.docx,.rtf,.txt,.md,.markdown,text/plain,text/markdown,text/rtf,application/rtf,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document" multiple hidden aria-hidden="true">
                 <textarea class="in" rows="1" placeholder="Pergunte sobre as peças… (@ cita uma peça · 📎 anexa arquivo)"></textarea>
                 <button class="send"><span class="lbl">Enviar</span>${SVG.enviar}</button>
               </div>
@@ -789,7 +789,7 @@ var PjePanel = (function () {
           <div class="mlib-card plib-card" role="dialog" aria-modal="true" aria-label="Modelos de peças" tabindex="-1">
             <div class="plib-hd">
               <span class="t">${SVG.modelos} Modelos de peças</span>
-              <button class="mlib-imp-btn plib-new" title="Importar peças-modelo de arquivos .docx — pode escolher vários de uma vez, e você confere tudo antes de cadastrar">${SVG.importar}<span class="lbl">Importar</span></button>
+              <button class="mlib-imp-btn plib-new" title="Importar peças-modelo de arquivos .docx ou .rtf — pode escolher vários de uma vez, e você confere tudo antes de cadastrar">${SVG.importar}<span class="lbl">Importar</span></button>
               <button class="mlib-new plib-new">${SVG.novo}<span class="lbl">Novo</span></button>
               <button class="mlib-close plib-close" title="Fechar (Esc)" aria-label="Fechar o gerenciador de modelos">${SVG.close}</button>
             </div>
@@ -808,9 +808,9 @@ var PjePanel = (function () {
             </div>
             <div class="mlib-imp" hidden>
               <div class="imp-rolo">
-                <div class="imp-drop" role="button" tabindex="0" aria-label="Escolher arquivos .docx — ou arraste os arquivos até aqui">
+                <div class="imp-drop" role="button" tabindex="0" aria-label="Escolher arquivos .docx ou .rtf — ou arraste os arquivos até aqui">
                   ${SVG.importarG}
-                  <span class="imp-drop-t">Arraste seus arquivos <b>.docx</b> até aqui</span>
+                  <span class="imp-drop-t">Arraste seus arquivos <b>.docx</b> ou <b>.rtf</b> até aqui</span>
                   <span class="imp-drop-s">ou clique para escolher — pode mandar vários de uma vez</span>
                 </div>
                 <div class="imp-prog" hidden>
@@ -831,7 +831,7 @@ var PjePanel = (function () {
               <div class="imp-acts imp-acts-fim" hidden>
                 <button class="imp-fechar plib-save">Voltar aos modelos</button>
               </div>
-              <input type="file" class="imp-file" accept=".docx" multiple hidden>
+              <input type="file" class="imp-file" accept=".docx,.rtf" multiple hidden>
             </div>
           </div>
         </div>
@@ -3475,7 +3475,7 @@ var PjePanel = (function () {
         mlibListEl.innerHTML =
           '<div class="plib-empty">Nenhum modelo cadastrado ainda.<br>' +
           (temDocx
-            ? "Use <b>Importar</b> para trazer vários arquivos <b>.docx</b> de uma vez, ou <b>Novo</b> para colar o texto"
+            ? "Use <b>Importar</b> para trazer vários arquivos <b>.docx</b> ou <b>.rtf</b> de uma vez, ou <b>Novo</b> para colar o texto"
             : "Clique em <b>Novo</b> para cadastrar sua primeira peça-modelo") +
           " — depois, ao gerar uma minuta, escolha a categoria em <b>Seguir modelos</b>.</div>";
         return;
@@ -3626,7 +3626,7 @@ var PjePanel = (function () {
       impDrop.classList.toggle("compacta", conferindo);
       impDrop.querySelector(".imp-drop-t").innerHTML = conferindo
         ? "Arraste ou clique para <b>adicionar mais</b>"
-        : "Arraste seus arquivos <b>.docx</b> até aqui";
+        : "Arraste seus arquivos <b>.docx</b> ou <b>.rtf</b> até aqui";
       impProg.hidden = qual !== "lendo";
       impFichasEl.hidden = qual === "resultado";
       // O rodapé aparece também no VAZIO, com só o "Voltar": sem ele, quem abriu

--- a/src/panel.js
+++ b/src/panel.js
@@ -284,6 +284,8 @@ var PjePanel = (function () {
     // mesmo desenho do botão "Importar de .docx" da página modelos.html: as
     // duas portas de entrada da importação precisam mostrar o mesmo ícone
     importar: '<path d="M12 20V9"/><path d="M7 13l5-5 5 5"/><path d="M5 4h14"/>',
+    // clipe de papel do botão de anexar arquivos no input
+    clip: '<path d="M20 11l-8.5 8.5a4 4 0 0 1-5.7-5.7l8.5-8.5a2.5 2.5 0 0 1 3.5 3.5l-8 8a1 1 0 0 1-1.4-1.4l7.3-7.3"/>',
   };
   // px = lado do ícone; w = stroke-width (a escala do DESIGN.md §5).
   function ic(paths, px, w) {
@@ -344,6 +346,7 @@ var PjePanel = (function () {
     importarG: ic(P.importar, 24, 1.4), // grande: traço mais fino (DESIGN.md §5)
     // --- demais ---
     info: ic(P.info, 15, 1.8),
+    clip: ic(P.clip, 16, 1.8),
     enviar: ic(P.enviar, 14, 2),
     chevron: ic(P.chevron, 11, 2.2),
     mais: ic(P.mais, 15, 1.8),
@@ -751,8 +754,11 @@ var PjePanel = (function () {
                 <button class="mapabar-x" title="Cancelar a geração do mapa mental (Esc)">${SVG.x}</button>
               </div>
               <div class="promptbar" hidden></div>
+              <div class="anexosbar" hidden></div>
               <div class="inrow">
-                <textarea class="in" rows="1" placeholder="Pergunte sobre as peças… (@ cita uma peça)"></textarea>
+                <button class="attach" title="Anexar arquivos (PDF, TXT ou Markdown) para analisar junto das peças — ou sozinhos" aria-label="Anexar arquivos">${SVG.clip}</button>
+                <input type="file" class="attach-input" accept=".pdf,.txt,.md,.markdown,text/plain,text/markdown,application/pdf" multiple hidden aria-hidden="true">
+                <textarea class="in" rows="1" placeholder="Pergunte sobre as peças… (@ cita uma peça · 📎 anexa arquivo)"></textarea>
                 <button class="send"><span class="lbl">Enviar</span>${SVG.enviar}</button>
               </div>
               <div class="hint-key"><div class="hk-in"><b>@</b> cita peças &nbsp;·&nbsp; <b>/</b> insere um prompt salvo &nbsp;·&nbsp; <b>Enter</b> envia <span class="hk-shift">&nbsp;·&nbsp; <b>Shift+Enter</b> quebra linha</span></div></div>
@@ -2903,6 +2909,54 @@ var PjePanel = (function () {
       promptbar.appendChild(hint);
     }
 
+    // ----- Anexos do input (📎): botão, campo de arquivo e chips -----
+    // A UI é reflexo: o content script é dono da lista (Map `anexos`) e a manda
+    // pronta em `setAnexos`. Aqui só disparamos a escolha, entregamos os File ao
+    // content script e desenhamos os chips.
+    const anexosbar = $(".anexosbar");
+    const attachBtn = $(".attach");
+    const attachInput = $(".attach-input");
+    let anexarCb = null;
+    let removerAnexoCb = null;
+    let anexosAtuais = [];
+    if (attachBtn && attachInput) {
+      attachBtn.addEventListener("click", () => attachInput.click());
+      attachInput.addEventListener("change", () => {
+        const files = [...(attachInput.files || [])];
+        // Zera SEMPRE: senão escolher o mesmo arquivo de novo não dispara change,
+        // e um arquivo que falhou nunca poderia ser re-tentado.
+        attachInput.value = "";
+        if (files.length && anexarCb) anexarCb(files);
+      });
+    }
+    // Desenha os chips dos anexos. `enviado` (já no contexto) muda só o título.
+    function renderAnexos(lista) {
+      anexosAtuais = Array.isArray(lista) ? lista : [];
+      if (!anexosbar) return;
+      anexosbar.innerHTML = "";
+      anexosbar.hidden = !anexosAtuais.length;
+      inrowEl.classList.toggle("com-anexo", !!anexosAtuais.length);
+      if (!anexosAtuais.length) return;
+      for (const a of anexosAtuais) {
+        const chip = document.createElement("span");
+        chip.className = "achip" + (a.enviado ? " enviado" : "");
+        const nome = a.nome || a.id;
+        chip.innerHTML =
+          '<span class="achip-i" aria-hidden="true">' + SVG.clip + "</span>" +
+          '<span class="achip-t" title="' + escapeHtml(nome) + (a.sub ? " — " + escapeHtml(a.sub) : "") +
+          (a.enviado ? " (no contexto)" : "") + '">' +
+          '<b>' + escapeHtml(tituloCurto(nome)) + "</b>" +
+          (a.sub ? '<span class="achip-s">' + escapeHtml(a.sub) + "</span>" : "") +
+          "</span>" +
+          '<button class="chip-x achip-x" title="Remover o anexo do contexto" aria-label="Remover ' +
+          escapeHtml(tituloCurto(nome)) + ' do contexto">' + SVG.x + "</button>";
+        chip.querySelector(".achip-x").addEventListener("click", () => {
+          if (removerAnexoCb) removerAnexoCb(a.id);
+        });
+        anexosbar.appendChild(chip);
+      }
+    }
+
     // ----- Gerenciador de prompts (modal .plib) -----
     function abrirPlib(opts) {
       opts = opts || {};
@@ -4347,6 +4401,18 @@ var PjePanel = (function () {
       onSelectionChange(cb) {
         selChangeCb = cb;
       },
+      // Anexos do input (📎). onAnexar recebe os File escolhidos; onRemoverAnexo
+      // recebe o id do anexo a soltar; setAnexos redesenha os chips a partir da
+      // lista que o content script mantém.
+      onAnexar(cb) {
+        anexarCb = cb;
+      },
+      onRemoverAnexo(cb) {
+        removerAnexoCb = cb;
+      },
+      setAnexos(lista) {
+        renderAnexos(lista);
+      },
       // Clique no botão "ver na timeline" de uma peça (recebe o id).
       onVerNaTimeline(cb) {
         verTimelineCb = cb;
@@ -4573,6 +4639,53 @@ var PjePanel = (function () {
           mexeu = true;
         }
         if (mexeu) syncSelection();
+      },
+      // Desmarca peças pelo id (checkbox = fonte de verdade). Usada quando o
+      // download de uma peça falha: tirá-la da seleção é o que impede que ela
+      // trave os próximos turnos. Cobre também a peça ainda LAZY (row não criada)
+      // removendo-a de `selPendente`, senão ela voltaria marcada no próximo
+      // setDocs. Devolve true se algo mudou.
+      desmarcarPecas(ids) {
+        if (!Array.isArray(ids) || !ids.length) return false;
+        let mexeu = false;
+        for (const id of ids) {
+          const c = doclist.querySelector('input[value="' + CSS.escape(id) + '"]');
+          if (c && c.checked) {
+            c.checked = false;
+            mexeu = true;
+          }
+          if (selPendente && selPendente.delete(id)) mexeu = true;
+        }
+        if (mexeu) syncSelection();
+        return mexeu;
+      },
+      // Marca peças pelo id, de forma ADITIVA (não desmarca nada). É o que faz o
+      // botão "adicionar peça citada" incluir no contexto uma peça que o modelo
+      // apontou como faltante. Peça ainda LAZY entra em `selPendente` (mesclado,
+      // não substituído como em `restaurarSelecao`) e é marcada quando a row
+      // aparecer. Devolve os ids que ainda não estavam marcados.
+      marcarPecas(ids) {
+        if (!Array.isArray(ids) || !ids.length) return [];
+        const novos = [];
+        let mexeu = false;
+        for (const id of ids) {
+          const c = doclist.querySelector('input[value="' + CSS.escape(id) + '"]');
+          if (c) {
+            if (!c.checked) {
+              c.checked = true;
+              mexeu = true;
+              novos.push(id);
+            }
+          } else {
+            if (!selPendente) selPendente = new Set();
+            if (!selPendente.has(id)) {
+              selPendente.add(id);
+              novos.push(id);
+            }
+          }
+        }
+        if (mexeu) syncSelection();
+        return novos;
       },
       clearMessages() {
         msgs.innerHTML = "";
@@ -4958,6 +5071,78 @@ var PjePanel = (function () {
           });
           box.appendChild(alt);
         }
+        el.appendChild(box);
+        msgs.scrollTop = msgs.scrollHeight;
+      },
+      // Peças que o modelo CITOU como faltantes (ids que ele mencionou mas que
+      // não estão no contexto) viram botões de "adicionar" abaixo da bolha. O
+      // modelo já faz o trabalho de apontar "o comprovante está na peça
+      // 214661494, que não foi anexada"; aqui esse id vira um clique que marca a
+      // peça — o usuário não precisa procurá-la na lista.
+      //
+      // Irmão do `.editor-act`: sobrevive ao `updateAssistant` (é filho do
+      // container do turno, não do `.body`). `info.pecas` = [{id, titulo}];
+      // `info.onAdd(ids)` marca as peças (o content script decide o que fazer).
+      sugerirPecas(el, info) {
+        if (!el || !info || !info.pecas || !info.pecas.length) return;
+        if (el.querySelector(".pecas-sug")) return; // uma vez por bolha
+        estruturaAssistant(el);
+        const box = document.createElement("div");
+        box.className = "pecas-sug";
+        const lab = document.createElement("div");
+        lab.className = "pecas-sug-lab";
+        lab.textContent =
+          info.pecas.length === 1
+            ? "Peça citada que não está no contexto:"
+            : "Peças citadas que não estão no contexto:";
+        box.appendChild(lab);
+        const linha = document.createElement("div");
+        linha.className = "pecas-sug-chips";
+        const marcados = new Set();
+        // troca o + pelo ✓ e desabilita (a peça já foi marcada)
+        function marcarFeito(btn) {
+          btn.classList.add("feito");
+          btn.disabled = true;
+          const svg = btn.querySelector("svg");
+          if (svg) svg.outerHTML = SVG.check;
+        }
+        for (const p of info.pecas) {
+          const b = document.createElement("button");
+          b.className = "pecas-sug-add";
+          b.dataset.id = p.id;
+          b.innerHTML =
+            SVG.novo +
+            '<span class="ps-id">' + escapeHtml(String(p.id)) + "</span>" +
+            (p.titulo ? '<span class="ps-t">' + escapeHtml(tituloCurto(p.titulo)) + "</span>" : "");
+          b.title = "Marcar “" + (p.titulo || p.id) + "” para incluí-la no próximo envio";
+          b.addEventListener("click", () => {
+            if (marcados.has(p.id)) return;
+            marcados.add(p.id);
+            marcarFeito(b);
+            if (info.onAdd) info.onAdd([p.id]);
+          });
+          linha.appendChild(b);
+        }
+        // "Adicionar todas" só quando há mais de uma: com uma peça o botão único
+        // já resolve.
+        if (info.pecas.length > 1) {
+          const todas = document.createElement("button");
+          todas.className = "pecas-sug-all";
+          todas.textContent = "Adicionar todas";
+          todas.addEventListener("click", () => {
+            const restantes = info.pecas.map((p) => p.id).filter((id) => !marcados.has(id));
+            if (!restantes.length) return;
+            for (const p of info.pecas) marcados.add(p.id);
+            for (const b of linha.querySelectorAll(".pecas-sug-add")) {
+              if (b.classList.contains("feito")) continue;
+              marcarFeito(b);
+            }
+            todas.disabled = true;
+            if (info.onAdd) info.onAdd(restantes);
+          });
+          linha.appendChild(todas);
+        }
+        box.appendChild(linha);
         el.appendChild(box);
         msgs.scrollTop = msgs.scrollHeight;
       },

--- a/src/panel.js
+++ b/src/panel.js
@@ -5321,6 +5321,7 @@ var PjePanel = (function () {
         btnMinuta.disabled = b;
         btnMapa.disabled = b;
         btnPlib.disabled = b;
+        if (attachBtn) attachBtn.disabled = b;
         const px = promptbar.querySelector(".pchip-x");
         if (px) px.disabled = b;
       },

--- a/src/panel.js
+++ b/src/panel.js
@@ -4677,10 +4677,14 @@ var PjePanel = (function () {
               novos.push(id);
             }
           } else {
+            // row ainda lazy: guarda em selPendente e conta como mudança para
+            // o syncSelection rodar — assim a memória (selecaoParaMemoria inclui
+            // selPendente) persiste a peça já, simétrico ao desmarcarPecas.
             if (!selPendente) selPendente = new Set();
             if (!selPendente.has(id)) {
               selPendente.add(id);
               novos.push(id);
+              mexeu = true;
             }
           }
         }

--- a/src/panel.js
+++ b/src/panel.js
@@ -756,8 +756,8 @@ var PjePanel = (function () {
               <div class="promptbar" hidden></div>
               <div class="anexosbar" hidden></div>
               <div class="inrow">
-                <button class="attach" title="Anexar arquivos (PDF, TXT ou Markdown) para analisar junto das peças — ou sozinhos" aria-label="Anexar arquivos">${SVG.clip}</button>
-                <input type="file" class="attach-input" accept=".pdf,.txt,.md,.markdown,text/plain,text/markdown,application/pdf" multiple hidden aria-hidden="true">
+                <button class="attach" title="Anexar arquivos (PDF, Word .docx, TXT ou Markdown) para analisar junto das peças — ou sozinhos" aria-label="Anexar arquivos">${SVG.clip}</button>
+                <input type="file" class="attach-input" accept=".pdf,.docx,.txt,.md,.markdown,text/plain,text/markdown,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document" multiple hidden aria-hidden="true">
                 <textarea class="in" rows="1" placeholder="Pergunte sobre as peças… (@ cita uma peça · 📎 anexa arquivo)"></textarea>
                 <button class="send"><span class="lbl">Enviar</span>${SVG.enviar}</button>
               </div>

--- a/src/pje.js
+++ b/src/pje.js
@@ -702,6 +702,22 @@ var PJE = (function () {
     return { kind: "text", fmt: ct.includes("html") ? "html" : "texto", text };
   }
 
+  // Lê um arquivo LOCAL que o usuário anexou no input (PDF, TXT, MD — e de
+  // quebra imagem, que `lerCorpo` já sabe tratar). REUSA `lerCorpo`, o mesmo
+  // leitor das peças do PJe, construindo uma Response a partir do File: assim
+  // não há um segundo detector de tipo nem um segundo extrator de texto que
+  // pudessem divergir deste — a mesma barreira de binário/imagem/PDF vale.
+  // A Response herda o content-type do próprio File (`file.type`); quando ele
+  // vem vazio (comum em `.md`), a detecção por assinatura de `lerCorpo` assume.
+  // Devolve o MESMO formato de `lerCorpo` ({kind, fmt, b64|text, ...}) e LANÇA,
+  // com mensagem amigável, quando o arquivo é vazio ou de um tipo não lido.
+  async function lerAnexo(file) {
+    const nome = (file && file.name) || "arquivo";
+    const corpo = await lerCorpo(new Response(file), nome);
+    if (!corpo) throw new Error('o arquivo "' + nome + '" está vazio ou não pôde ser lido.');
+    return corpo;
+  }
+
   // Rola a timeline do PJe até a peça e a destaca com um flash temporário.
   // NÃO clica no link (zero efeito A4J/JSF, não entra na activationChain) —
   // é só navegação visual. Retorna false quando a peça não está na timeline
@@ -1171,6 +1187,7 @@ var PJE = (function () {
     scrollAte,
     carregarTimelineCompleta,
     listarPelaGrid,
+    lerAnexo,
     // expostos para teste fora do navegador
     _acharGrid: acharGrid,
     _mapaColunas: mapaColunas,


### PR DESCRIPTION
## Resumo

Melhorias no fluxo do chat, encaixadas na arquitetura existente **sem regressão** e sem build step. Todas cobertas por testes fora do navegador (syntax, lint `no-undef`, boot em jsdom, leitura real de anexo, extração de predicados, extração de `.docx`).

Commits principais:
1. `feat(chat)` — as três funcionalidades
2. `refactor(chat)` — proteção da retomada sem anexo + trava do 📎 durante o turno
3. `fix(anexos)` — bug crítico pego em revisão adversária
4. `feat(anexos)` — aceitar `.docx` no input, extraindo o texto no cliente

---

## 1. Peça com erro não trava mais o chat

**Problema:** quando uma peça falha no download, o 1º turno segue com as demais — mas a peça continuava marcada, era **re-tentada a cada turno** e, quando era a única peça "nova", **abortava o turno seguinte inteiro**. O usuário tinha de caçar e desmarcá-la à mão.

**Correção:** a peça que falha é **retirada da seleção automaticamente** (`panel.desmarcarPecas`, que cobre a row lazy via `selPendente`), a análise segue com o restante, e o aviso explica que ela saiu e como reanexar. O turno **só falha de vez** quando não há mais nada — nem histórico, nem anexo.

## 2. Anexos no input (📎)

Botão de clipe ao lado da caixa de mensagem: o usuário anexa **PDF, Word (.docx), TXT e Markdown**, junto das peças marcadas **ou sozinho**.

- **Cada formato pela rota certa** — a diferença é o suporte NATIVO dos provedores (Anthropic/Gemini/OpenAI), conferido nas docs:
  - **PDF** → bloco `document`/`file`: o provedor processa com **texto + imagem de página (visão)** nativamente — mesmo caminho das peças PDF.
  - **TXT/MD** → bloco de texto puro.
  - **DOCX** → **nenhum provedor lê `.docx` nativamente como documento**, então o **texto é extraído no cliente** (reusa `DocxImport`: ZIP + `DecompressionStream` + `DOMParser`, sem lib nova) e entra como bloco de texto, igual ao TXT/MD.
- **Mesma máquina de blocos das peças:** id sintético `anexo:<n>` + `entradaDoc`; respeitam tetos de páginas/tokens/base64 e o pré-voo; PDF sobe à Files API por `subirAnexos`.
- **Sessão apenas** (nada de bytes de arquivo do usuário no disco): "Nova conversa" solta os anexos; conversa retomada remove os blocos de anexo do histórico com aviso. Chips com remover na nova `.anexosbar`.

## 3. Peça citada como faltante vira um clique

Quando a resposta aponta ids que não estão no contexto ("o comprovante está na peça 214661494, não anexada"), surgem **botões de adicionar** abaixo da bolha (`panel.sugerirPecas` + `panel.marcarPecas`, aditivo). Só ids que são peça REAL da timeline entram — elimina falso positivo de número solto.

---

## 🐛 Bug crítico encontrado e corrigido na revisão

Revisão adversária do diff pegou um bug que os testes iniciais não cobriam: `podeAnexar` lia `docsCache.get(id)` direto, mas os anexos vivem só na Map `anexos`. Resultado: **todo anexo caía em `semConteudo` dentro de `montarBlocos`**, nunca virava bloco e nunca chegava ao modelo — com um erro falso ("o envio anterior expirou") a cada envio. Corrigido (lê por `entradaDoc`) e coberto por teste que extrai `podeAnexar`/`entradaDoc`/`fileIdValido` do fonte real.

---

## Como foi testado (fora do navegador)

- `node --check` em content.js, panel.js, pje.js ✓
- ESLint `no-undef`/`no-unused-vars` — sem problema novo ✓
- **Boot em jsdom** (panel.js + content.js): painel monta, 📎/input/`.anexosbar` existem, e `marcarPecas`/`desmarcarPecas`/`setAnexos`/`sugerirPecas` funcionam (21 asserções) ✓
- **`PJE.lerAnexo` real** para `.txt`, `.md`, `.pdf` (páginas + base64) e recusa de arquivo vazio ✓
- **Extração de `.docx`** — `.docx` fabricado com o `ZipW` do repo é lido por `DocxImport`; `.doc` recusado com mensagem clara ✓
- **Predicados** — confirma o fix do bug crítico + não-regressão das peças ✓

## Não regride

- Minuta, mapa e "escolher com IA" seguem só com peças — intocados.
- `entradaDoc` para id de peça devolve exatamente `docsCache.get` — peças, memória de caso, exportação `.zip`, preview e estimativa idênticos.
- Retomada de conversa **sem anexo** não é tocada (o strip só reescreve `turno.content` quando há de fato um bloco `anexo:`).

## Limitações conhecidas (v1)

- Anexos não sobrevivem entre sessões (por design; a conversa retomada avisa).
- Anexos são recurso do chat; minuta/mapa não os consomem.
- `.docx` entra como texto (imagens/formatação do Word não vão ao modelo — o teor textual, sim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)